### PR TITLE
fix(dataproducer): preserve positional TS signature for paginated ops (2.1.1)

### DIFF
--- a/package/avigilon/alta/access/gate-stamp.json
+++ b/package/avigilon/alta/access/gate-stamp.json
@@ -1,7 +1,7 @@
 {
-  "version": "2.0.2",
-  "branch": "dataproducer_2_1",
-  "timestamp": "2026-04-27T22:27:59.651250930Z",
+  "version": "2.0.2-uat.0",
+  "branch": "dataproducer_2_1_1",
+  "timestamp": "2026-04-28T01:06:49.907624222Z",
   "sourceHash": "b1c966533eae3b8035e939dbcafcd86d98617c004004ceef9d156fc1cf19913a",
   "testHash": "c86593489cf8da5826b448b6e769abb3937c8ec54cb6b4e2a647b4f9c55c30fc",
   "tasks": {

--- a/package/avigilon/alta/access/package-lock.json
+++ b/package/avigilon/alta/access/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zerobias-org/module-avigilon-alta-access",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zerobias-org/module-avigilon-alta-access",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "UNLICENSED",
       "dependencies": {
         "@zerobias-org/logger": "3.0.7",

--- a/package/interface/dataproducer/api.yml
+++ b/package/interface/dataproducer/api.yml
@@ -67,9 +67,12 @@ paths:
       summary: Get child objects
       description: Returns paged results of objects that are children of the specified object
       operationId: getChildren
+      # Parameter order is load-bearing: codegen mirrors it into TypeScript
+      # positional args. New optional params (pageTokenParam) are appended
+      # at the end so existing callers from 1.2.x / 2.0.x continue to
+      # compile against 2.1.x. Don't insert in the middle.
       parameters:
         - $ref: '#/components/parameters/objectId'
-        - $ref: '#/components/parameters/pageTokenParam'
         - $ref: '#/components/parameters/pageNumberParam'
         - $ref: '#/components/parameters/pageSizeParam'
         - $ref: '#/components/parameters/sortByParam'
@@ -90,6 +93,7 @@ paths:
             type: array
             items:
               type: string
+        - $ref: '#/components/parameters/pageTokenParam'
       responses:
         '200':
           description: List of child objects
@@ -156,14 +160,15 @@ paths:
       summary: Search objects
       description: Performs keyword search or filtered search within object hierarchy. Either keywords or filter must be provided, but not both.
       operationId: objectSearch
+      # New optional params (pageTokenParam, propertiesParam) appended at
+      # the end to keep the positional TS signature stable for 1.2.x / 2.0.x
+      # callers. See note on getChildren above.
       parameters:
         - $ref: '#/components/parameters/objectId'
-        - $ref: '#/components/parameters/pageTokenParam'
         - $ref: '#/components/parameters/pageNumberParam'
         - $ref: '#/components/parameters/pageSizeParam'
         - $ref: '#/components/parameters/sortByParam'
         - $ref: '#/components/parameters/sortDirParam'
-        - $ref: '#/components/parameters/propertiesParam'
         - $ref: '#/components/parameters/scopeParam'
         - name: keywords
           in: query
@@ -179,6 +184,8 @@ paths:
           description: RFC4515 structured filter expression (mutually exclusive with keywords)
           schema:
             type: string
+        - $ref: '#/components/parameters/pageTokenParam'
+        - $ref: '#/components/parameters/propertiesParam'
       responses:
         '200':
           description: Search results
@@ -208,14 +215,15 @@ paths:
         - /children: Simple listing with basic type/tag filters
         - /searchChildren: Advanced RFC4515 filtering + property projection
       operationId: searchChildObjects
+      # New endpoint in 2.x — no positional compat to preserve, but ordering
+      # follows the same convention as the other paginated ops: opt-in
+      # cursor/projection params at the end.
       parameters:
         - $ref: '#/components/parameters/objectId'
-        - $ref: '#/components/parameters/pageTokenParam'
         - $ref: '#/components/parameters/pageNumberParam'
         - $ref: '#/components/parameters/pageSizeParam'
         - $ref: '#/components/parameters/sortByParam'
         - $ref: '#/components/parameters/sortDirParam'
-        - $ref: '#/components/parameters/propertiesParam'
         - name: filter
           in: query
           required: false
@@ -224,6 +232,8 @@ paths:
             type: string
           example: "(&(objectClass=document)(tags=*important*)(modified>=2023-01-01))"
         - $ref: '#/components/parameters/scopeParam'
+        - $ref: '#/components/parameters/pageTokenParam'
+        - $ref: '#/components/parameters/propertiesParam'
         - name: includeCount
           in: query
           required: false
@@ -255,13 +265,14 @@ paths:
       summary: Get collection elements
       description: Returns paged collection data for collection objects
       operationId: getCollectionElements
+      # New optional params appended; see note on getChildren above.
       parameters:
         - $ref: '#/components/parameters/objectId'
-        - $ref: '#/components/parameters/pageTokenParam'
         - $ref: '#/components/parameters/pageNumberParam'
         - $ref: '#/components/parameters/pageSizeParam'
         - $ref: '#/components/parameters/sortByParam'
         - $ref: '#/components/parameters/sortDirParam'
+        - $ref: '#/components/parameters/pageTokenParam'
         - $ref: '#/components/parameters/propertiesParam'
       responses:
         '200':
@@ -406,9 +417,9 @@ paths:
       summary: Search collection elements
       description: Filtered search within collection data
       operationId: searchCollectionElements
+      # New optional params appended; see note on getChildren above.
       parameters:
         - $ref: '#/components/parameters/objectId'
-        - $ref: '#/components/parameters/pageTokenParam'
         - $ref: '#/components/parameters/pageNumberParam'
         - $ref: '#/components/parameters/pageSizeParam'
         - name: filter
@@ -419,6 +430,7 @@ paths:
             type: string
         - $ref: '#/components/parameters/sortByParam'
         - $ref: '#/components/parameters/sortDirParam'
+        - $ref: '#/components/parameters/pageTokenParam'
         - $ref: '#/components/parameters/propertiesParam'
       responses:
         '200':

--- a/package/interface/dataproducer/gate-stamp.json
+++ b/package/interface/dataproducer/gate-stamp.json
@@ -1,8 +1,8 @@
 {
-  "version": "2.1.0",
-  "branch": "dataproducer_2_1",
-  "timestamp": "2026-04-27T22:27:14.461976116Z",
-  "sourceHash": "98c1c4a6349402db680b174771bbd7e76ba012be9457408c9d35d9595978d0ad",
+  "version": "2.1.1-uat.0",
+  "branch": "dataproducer_2_1_1",
+  "timestamp": "2026-04-28T01:06:13.285208539Z",
+  "sourceHash": "8bd40ad905d5dfe9efa3f26c9ed35bb7023e3275d9441ec8ee0c256f400481f1",
   "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "tasks": {
     "validate": "passed",

--- a/package/interface/dataproducer/package.json
+++ b/package/interface/dataproducer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/module-interface-dataproducer",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Dynamic Data Producer Interface",
   "moduleId": "a2b032b3-eb87-4cb8-8916-8fbbd4c3fcef",
   "type": "module",

--- a/package/readyplayerme/readyplayerme/gate-stamp.json
+++ b/package/readyplayerme/readyplayerme/gate-stamp.json
@@ -1,7 +1,7 @@
 {
-  "version": "2.0.2",
-  "branch": "dataproducer_2_1",
-  "timestamp": "2026-04-27T22:27:41.529640028Z",
+  "version": "2.0.2-uat.0",
+  "branch": "dataproducer_2_1_1",
+  "timestamp": "2026-04-28T01:06:40.143128712Z",
   "sourceHash": "0686d544fc26aca5830a88e765dcbf5161e5d5443df1b52469b5cf1c8706996d",
   "testHash": "8200265d17a9a8b377662ef2e784017a4483e33d076b474033ab9c2b1d7cb0bd",
   "tasks": {

--- a/package/readyplayerme/readyplayerme/package-lock.json
+++ b/package/readyplayerme/readyplayerme/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zerobias-org/module-readyplayerme-readyplayerme",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zerobias-org/module-readyplayerme-readyplayerme",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "UNLICENSED",
       "dependencies": {
         "@zerobias-org/logger": "3.0.7",


### PR DESCRIPTION
## Summary

Restores backward-compatible TypeScript signatures for paginated DataProducer operations. The 2.0.x V2 work added `pageTokenParam` and `propertiesParam` by **inserting** them in the middle of each paginated operation's parameter list — between `objectId` and `pageNumberParam` for `pageTokenParam`, and between `sortDirParam` and the operation-specific params for `propertiesParam`. Codegen mirrors OpenAPI parameter order into TypeScript positional args, so this shifted every existing positional caller (1.2.x → 2.0.x) by one or two slots and broke them silently at runtime.

This was caught while running the SQL module's e2e tests against 2.1.0 — `getChildren('/', 1, 10)` was binding `1` as `pageToken: string` and `10` as `pageNumber`, returning empty / unfiltered results. The type system would have caught it earlier, but module test files weren't being typechecked (separate fix in build-tools — see companion CR).

**Fix:** append both new optional params at the **end** of each affected operation. Existing callers that pass `(objectId, pageNumber, pageSize, ...)` continue to work; new callers wanting cursor pagination or property projection opt in by passing the trailing arg.

**Affected operations** in `api.yml`:
- `getChildren` — append `pageTokenParam`
- `objectSearch` — append `pageTokenParam`, `propertiesParam`
- `searchChildObjects` (new in 2.x — no compat impact, reordered for consistency)
- `getCollectionElements` — append `pageTokenParam`, `propertiesParam`
- `searchCollectionElements` — append `pageTokenParam`, `propertiesParam`

**Versioning:** 2.1.0 → 2.1.1. Replaces the previously-published 2.1.0, which contained the same V2 break inherited from 2.0.x and was unpublished from `pkg.zerobias.org` after the regression surfaced.

## Test plan

- [x] `npx js-yaml api.yml` parses cleanly
- [x] All 105 internal `$ref`s resolve
- [x] Published 2.1.1 to local `pkg-proxy` and pulled into the SQL module (`@auditlogic/module-auditmation-generic-sql`) via `npm install`
- [x] SQL module's `test/e2e/sql.test.ts` now passes against 2.1.1 in docker mode (13 passing, 5 pending, 0 failing) — the same positional `getChildren('/', 1, 10)` calls that broke against 2.1.0 now work
- [ ] Verify on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)