### PR TITLE
chore(dataproducer): bump types-core peer deps to v2

### DIFF
--- a/package/interface/dataproducer/hub-sdk/package.json
+++ b/package/interface/dataproducer/hub-sdk/package.json
@@ -21,7 +21,7 @@
   },
   "files": ["dist"],
   "peerDependencies": {
-    "@zerobias-org/types-core-js": "^1.2.19",
+    "@zerobias-org/types-core-js": "^2.0.3",
     "@zerobias-org/util-connector": "^1.0.40",
     "axios": "^1.0.0"
   },

--- a/package/interface/dataproducer/package-lock.json
+++ b/package/interface/dataproducer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zerobias-org/module-interface-dataproducer",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zerobias-org/module-interface-dataproducer",
-      "version": "2.1.3",
+      "version": "2.1.4",
       "license": "UNLICENSED",
       "dependencies": {
         "@zerobias-org/product-zerobias-zerobias": "latest",
@@ -26,8 +26,8 @@
         "typescript": "5.9.3"
       },
       "peerDependencies": {
-        "@zerobias-org/types-core": "^1.0.22",
-        "@zerobias-org/types-core-js": "^1.2.19"
+        "@zerobias-org/types-core": "^2.0.1",
+        "@zerobias-org/types-core-js": "^2.0.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1669,15 +1669,99 @@
       }
     },
     "node_modules/@zerobias-org/types-core": {
+      "version": "2.0.1",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/types-core/-/types-core-2.0.1.tgz",
+      "integrity": "sha512-y2IAVF74u2gIUNdwTK2HaGYAuGQHaKQM0yV3POCbTSiJSZf+wopdLS6SnbCX8VmxlrYbsr49t7Qb9lGRjYMNqg==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/@zerobias-org/types-core-js": {
+      "version": "2.0.3",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/types-core-js/-/types-core-js-2.0.3.tgz",
+      "integrity": "sha512-u+q9IkaQ+nBhqFHg0yqnhlz3tpLHvdbvpqYJ9+EgYdKVzsLLHnlXvXV365JTOXXu9UgVBY+/3U9bFpqvOpYHNg==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "@zerobias-org/types-core": "2.0.1",
+        "awesome-phonenumber": "^7.6.0",
+        "axios": "^1.16.0",
+        "cron-parser": "^5.4.0",
+        "ip-num": "^1.5.1",
+        "iso8601-duration": "^2.1.2",
+        "p-limit": "^6.2.0",
+        "pluralize-esm": "^9.0.5",
+        "safe-stable-stringify": "^2.5.0",
+        "semver": "^7.7.3",
+        "uuid": "^13.0.0",
+        "vuln-vects": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@zerobias-org/types-core-js/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/@zerobias-org/types-core-js/node_modules/axios": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/@zerobias-org/types-core-js/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@zerobias-org/util-api-client-base": {
+      "version": "1.0.44",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/util-api-client-base/-/util-api-client-base-1.0.44.tgz",
+      "integrity": "sha512-suY7XK8Vg+WqG0+8UitCQWHpzOUa9Y5M7TOTV+TfyxxyYPeLCWFX0GLt+EfwJFSwis8IoPOYqFFHNrp1wSedig==",
+      "license": "ISC",
+      "dependencies": {
+        "@zerobias-org/types-core-js": "^1.2.23",
+        "@zerobias-org/util-api-invoker-api": "^1.0.37",
+        "@zerobias-org/util-api-invoker-isomorphic": "^1.0.38",
+        "axios": "^1.15.0",
+        "qs": "^6.14.0"
+      }
+    },
+    "node_modules/@zerobias-org/util-api-client-base/node_modules/@zerobias-org/types-core": {
       "version": "1.0.24",
       "resolved": "https://pkg.zerobias.org/@zerobias-org/types-core/-/types-core-1.0.24.tgz",
       "integrity": "sha512-HXHx5t4b6QlZ62NOc65Qrfo3rksQ+anXhTyqDjEr9C46ancTS0ftba4nMwPpCyB+X3NjPvKd3v1zgRCKZrfu6w==",
       "license": "ISC"
     },
-    "node_modules/@zerobias-org/types-core-js": {
-      "version": "1.2.23",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/types-core-js/-/types-core-js-1.2.23.tgz",
-      "integrity": "sha512-mFroi5luXuucy1DG1vpvXUioCTqwzjCQBZdJ18kiWJO24XKMNi0ckPQJTALtscMURk1NYyBN38YNlNBwTcts1g==",
+    "node_modules/@zerobias-org/util-api-client-base/node_modules/@zerobias-org/types-core-js": {
+      "version": "1.2.27",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/types-core-js/-/types-core-js-1.2.27.tgz",
+      "integrity": "sha512-s70hpQM01O6YZXoJYMX8sp04SFC2J7mTIxAd+7P7DMWpdNAtUqbO8/zM015YyB6r2TTq3YKVnvIWG1jZ0THrfQ==",
       "license": "ISC",
       "dependencies": {
         "@zerobias-org/types-core": "1.0.24",
@@ -1697,19 +1781,6 @@
         "node": ">=22.0.0"
       }
     },
-    "node_modules/@zerobias-org/util-api-client-base": {
-      "version": "1.0.44",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/util-api-client-base/-/util-api-client-base-1.0.44.tgz",
-      "integrity": "sha512-suY7XK8Vg+WqG0+8UitCQWHpzOUa9Y5M7TOTV+TfyxxyYPeLCWFX0GLt+EfwJFSwis8IoPOYqFFHNrp1wSedig==",
-      "license": "ISC",
-      "dependencies": {
-        "@zerobias-org/types-core-js": "^1.2.23",
-        "@zerobias-org/util-api-invoker-api": "^1.0.37",
-        "@zerobias-org/util-api-invoker-isomorphic": "^1.0.38",
-        "axios": "^1.15.0",
-        "qs": "^6.14.0"
-      }
-    },
     "node_modules/@zerobias-org/util-api-invoker-api": {
       "version": "1.0.37",
       "resolved": "https://pkg.zerobias.org/@zerobias-org/util-api-invoker-api/-/util-api-invoker-api-1.0.37.tgz",
@@ -1718,6 +1789,35 @@
       "dependencies": {
         "@zerobias-org/types-core-js": "^1.2.23",
         "axios": "^1.15.0"
+      }
+    },
+    "node_modules/@zerobias-org/util-api-invoker-api/node_modules/@zerobias-org/types-core": {
+      "version": "1.0.24",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/types-core/-/types-core-1.0.24.tgz",
+      "integrity": "sha512-HXHx5t4b6QlZ62NOc65Qrfo3rksQ+anXhTyqDjEr9C46ancTS0ftba4nMwPpCyB+X3NjPvKd3v1zgRCKZrfu6w==",
+      "license": "ISC"
+    },
+    "node_modules/@zerobias-org/util-api-invoker-api/node_modules/@zerobias-org/types-core-js": {
+      "version": "1.2.27",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/types-core-js/-/types-core-js-1.2.27.tgz",
+      "integrity": "sha512-s70hpQM01O6YZXoJYMX8sp04SFC2J7mTIxAd+7P7DMWpdNAtUqbO8/zM015YyB6r2TTq3YKVnvIWG1jZ0THrfQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@zerobias-org/types-core": "1.0.24",
+        "awesome-phonenumber": "^7.6.0",
+        "axios": "^1.13.2",
+        "cron-parser": "^5.4.0",
+        "ip-num": "^1.5.1",
+        "iso8601-duration": "^2.1.2",
+        "p-limit": "^6.2.0",
+        "pluralize-esm": "^9.0.5",
+        "safe-stable-stringify": "^2.5.0",
+        "semver": "^7.7.3",
+        "uuid": "^13.0.0",
+        "vuln-vects": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@zerobias-org/util-api-invoker-isomorphic": {
@@ -1731,6 +1831,35 @@
         "axios": "^1.15.0",
         "form-data": "^4.0.0",
         "qs": "^6.14.0"
+      }
+    },
+    "node_modules/@zerobias-org/util-api-invoker-isomorphic/node_modules/@zerobias-org/types-core": {
+      "version": "1.0.24",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/types-core/-/types-core-1.0.24.tgz",
+      "integrity": "sha512-HXHx5t4b6QlZ62NOc65Qrfo3rksQ+anXhTyqDjEr9C46ancTS0ftba4nMwPpCyB+X3NjPvKd3v1zgRCKZrfu6w==",
+      "license": "ISC"
+    },
+    "node_modules/@zerobias-org/util-api-invoker-isomorphic/node_modules/@zerobias-org/types-core-js": {
+      "version": "1.2.27",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/types-core-js/-/types-core-js-1.2.27.tgz",
+      "integrity": "sha512-s70hpQM01O6YZXoJYMX8sp04SFC2J7mTIxAd+7P7DMWpdNAtUqbO8/zM015YyB6r2TTq3YKVnvIWG1jZ0THrfQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@zerobias-org/types-core": "1.0.24",
+        "awesome-phonenumber": "^7.6.0",
+        "axios": "^1.13.2",
+        "cron-parser": "^5.4.0",
+        "ip-num": "^1.5.1",
+        "iso8601-duration": "^2.1.2",
+        "p-limit": "^6.2.0",
+        "pluralize-esm": "^9.0.5",
+        "safe-stable-stringify": "^2.5.0",
+        "semver": "^7.7.3",
+        "uuid": "^13.0.0",
+        "vuln-vects": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@zerobias-org/util-codegen": {
@@ -1763,6 +1892,35 @@
       "engines": {
         "node": ">=22.0.0",
         "npm": ">=10.0.0"
+      }
+    },
+    "node_modules/@zerobias-org/util-connector/node_modules/@zerobias-org/types-core": {
+      "version": "1.0.24",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/types-core/-/types-core-1.0.24.tgz",
+      "integrity": "sha512-HXHx5t4b6QlZ62NOc65Qrfo3rksQ+anXhTyqDjEr9C46ancTS0ftba4nMwPpCyB+X3NjPvKd3v1zgRCKZrfu6w==",
+      "license": "ISC"
+    },
+    "node_modules/@zerobias-org/util-connector/node_modules/@zerobias-org/types-core-js": {
+      "version": "1.2.27",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/types-core-js/-/types-core-js-1.2.27.tgz",
+      "integrity": "sha512-s70hpQM01O6YZXoJYMX8sp04SFC2J7mTIxAd+7P7DMWpdNAtUqbO8/zM015YyB6r2TTq3YKVnvIWG1jZ0THrfQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@zerobias-org/types-core": "1.0.24",
+        "awesome-phonenumber": "^7.6.0",
+        "axios": "^1.13.2",
+        "cron-parser": "^5.4.0",
+        "ip-num": "^1.5.1",
+        "iso8601-duration": "^2.1.2",
+        "p-limit": "^6.2.0",
+        "pluralize-esm": "^9.0.5",
+        "safe-stable-stringify": "^2.5.0",
+        "semver": "^7.7.3",
+        "uuid": "^13.0.0",
+        "vuln-vects": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@zerobias-org/vendor-zerobias": {
@@ -2287,7 +2445,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"

--- a/package/interface/dataproducer/package.json
+++ b/package/interface/dataproducer/package.json
@@ -54,8 +54,8 @@
     "axios": "1.15.0"
   },
   "peerDependencies": {
-    "@zerobias-org/types-core": "^1.0.22",
-    "@zerobias-org/types-core-js": "^1.2.19"
+    "@zerobias-org/types-core": "^2.0.1",
+    "@zerobias-org/types-core-js": "^2.0.3"
   },
   "devDependencies": {
     "@redocly/cli": "2.28.1",


### PR DESCRIPTION
## What

Bumps the `types-core` peer dependency ranges on the **dataproducer interface** package to the v2 major (now `latest` on npm):

| Package | Before | After |
|---|---|---|
| `@zerobias-org/types-core` | `^1.0.22` | `^2.0.1` |
| `@zerobias-org/types-core-js` | `^1.2.19` | `^2.0.3` |
| `@zerobias-org/types-core-js` (hub-sdk) | `^1.2.19` | `^2.0.3` |

## Why peer (unchanged)

`types-core-js` is the shared framework runtime — generated code imports runtime singletons (`UUID`, `CoreType`, the `CoreError` hierarchy, `EnumValue` registries) that must be a single instance across all modules loaded into a host. Keeping it as a `peerDependency` lets the host provide one copy and avoids duplicate-registry / `instanceof` breakage. Only the version range changed.

## Verification

- `./gradlew :interface:dataproducer:clean :interface:dataproducer:gate` → **BUILD SUCCESSFUL** (generate → compile → unit + dataloader tests)
- Resolved `types-core@2.0.1` / `types-core-js@2.0.3` in `node_modules`

## Note

This diverges from the sibling modules (avigilon, readyplayerme), which are still on the v1 line (`^1.0.24 / ^1.2.23`). Follow-up may be warranted to bring those to v2 for repo-wide consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)