### PR TITLE
feat(hl7/v2): HL7 v2.7 + PagedResults fix + MLLP port 2575 (1.2.0)

### DIFF
--- a/package/hl7/v2/CLAUDE.md
+++ b/package/hl7/v2/CLAUDE.md
@@ -29,7 +29,7 @@ runtimeConfig.yml    daemonMode + listenerPorts[mllp] + durability + opaque conf
 Dockerfile  nginx.conf  nginx-insecure.conf  startup.sh    container (nginx → java on 8889)
 java/
 ├── pom.xml          uber jar (maven-shade); codegen runs at generate-resources (NOT a profile)
-├── codegen/         BUILD-TIME ONLY (depends hapi-structures-v251); emits schemas/ + structure-index
+├── codegen/         BUILD-TIME ONLY (depends hapi-structures-v27); emits schemas/ + structure-index
 └── src/main/java/com/zerobias/module/hl7/
     ├── Hl7ApiServer.java     entry point: boots daemon (buffer+listener) + Javalin RPC routes
     ├── ModuleConfig.java / ModuleRuntimeConfig.java   env (LISTENER_PORT_MLLP, MODULE_CONFIG)
@@ -116,8 +116,12 @@ cd <repo-root> && ./gradlew :hl7:v2:gate          # gradle path is :hl7:v2 (auto
   client) each set a **dedicated** executor. If you add another HAPI client, give it
   its own executor. (This bug made the listener silently die after startup.)
 - **Real bean names ≠ DESIGN §5's idealized ones.** Materialized JSON uses HAPI's
-  actual names: `IDNumber`, `namespaceID`, `dateTimeOfBirth` (TS is a composite →
-  dates nest under `time`). The schemas match; §5's `idNumber`/`surname` are illustrative.
+  actual names: `IDNumber`, `namespaceID`, `dateTimeOfBirth`. The schemas match; §5's
+  `idNumber`/`surname` are illustrative. **v2.7 datatype gotcha:** `dateTimeOfBirth`
+  is a `DTM` *primitive* (flat string — v2.5.1's `TS` composite that nested under
+  `time` was retired) and `administrativeSex` is a `CWE` *composite* (`{"identifier":"M"}`,
+  was an `IS` primitive in v2.5.1). The target version is config-driven
+  (`runtimeConfig.config.hl7Version`, default `2.7` → slot `v27`).
 - **Error envelope = OpenAPI `errorModelBase`** (`{key, template, timestamp, statusCode}`
   + `noSuchObjectError.{type,id}` / `illegalArgumentError.{msg}`), NOT the
   `{code,message,details}` shown in `Errors.md` prose. When interface docs disagree,

--- a/package/hl7/v2/CLAUDE.md
+++ b/package/hl7/v2/CLAUDE.md
@@ -55,6 +55,16 @@ proxies everything to Javalin, which serves the SQL-module RPC envelope:
 maps operationIds onto the RPC route. (The reference SQL module's api.yml likewise
 doesn't match its Javalin routes.)
 
+**Paginated ops MUST return a `PagedResults` envelope, not a bare array.** Even
+though the OpenAPI response schema for `getChildren`/`searchChildObjects`/
+`getCollectionElements`/`searchCollectionElements` is `type: array`, the platform's
+generated producer client deserializes the RPC body into a paged bag and throws
+*"Producers must return 'items' for PagedResults queries"* (breaking the
+data-explorer tree) if the body isn't `{"items":[...],"count":N,"pageSize":P,
+"pageNumber":N}`. `Hl7ProducerFacade.pagedResults(...)` wraps them; `pageNumber` is
+1-based on the wire. See `auditlogic/module/IMPROVEMENTS.md` §"PagedResults Format".
+This was the boss-facing blocker fixed once — don't return a raw array again.
+
 ## Validating changes
 
 **Run the JUnit suite after a change** — it's the canonical test surface (45 tests:

--- a/package/hl7/v2/DESIGN.md
+++ b/package/hl7/v2/DESIGN.md
@@ -90,16 +90,16 @@ Canonical form (per [`SchemaIds.md`](../../interface/dataproducer/documentation/
 
 | Schema ID | Purpose |
 |---|---|
-| `schema:table:hl7v2.v251.ADT_A01` | Collection schema for `/by-type/ADT_A01` |
-| `schema:table:hl7v2.v251.ORU_R01` | Collection schema for `/by-type/ORU_R01` |
-| `schema:type:hl7v2.v251.MSH` | MSH segment (composite, referenced from messages) |
-| `schema:type:hl7v2.v251.PID` | PID segment |
-| `schema:type:hl7v2.v251.CX` | CX datatype (extended composite ID with check digit) |
-| `schema:type:hl7v2.v251.XPN` | XPN datatype (extended person name) |
-| `schema:type:hl7v2.v251.HD` | HD datatype (hierarchic designator) |
-| `schema:enum:hl7v2.v251.HL70001` | Administrative Sex value set |
-| `schema:enum:hl7v2.v251.HL70003` | Event Type value set |
-| `schema:enum:hl7v2.v251.HL70076` | Message Type value set |
+| `schema:table:hl7v2.v27.ADT_A01` | Collection schema for `/by-type/ADT_A01` |
+| `schema:table:hl7v2.v27.ORU_R01` | Collection schema for `/by-type/ORU_R01` |
+| `schema:type:hl7v2.v27.MSH` | MSH segment (composite, referenced from messages) |
+| `schema:type:hl7v2.v27.PID` | PID segment |
+| `schema:type:hl7v2.v27.CX` | CX datatype (extended composite ID with check digit) |
+| `schema:type:hl7v2.v27.XPN` | XPN datatype (extended person name) |
+| `schema:type:hl7v2.v27.HD` | HD datatype (hierarchic designator) |
+| `schema:enum:hl7v2.v27.HL70136` | Yes/No Indicator value set (PID death / multiple-birth indicators) |
+| `schema:enum:hl7v2.v27.HL70003` | Event Type value set |
+| `schema:enum:hl7v2.v27.HL70203` | Identifier Type value set (CX-5) |
 | `schema:type:hl7v2.epic.ZPV` | Epic Z-segment (from `@zerobias-org/hl7-extension-epic-adt`) |
 | `schema:enum:hl7v2.local.HL79001` | Customer local enum (from a `@<customer-scope>/hl7-extension-*` pack) |
 | `schema:shared:hl7v2.message-envelope` | Common envelope fields across all message types (`controlId`, `receivedAt`, `status`, `leaseId`) |
@@ -107,16 +107,16 @@ Canonical form (per [`SchemaIds.md`](../../interface/dataproducer/documentation/
 | `schema:function:hl7v2.ops.ack:input` / `:output` | `ops/ack` I/O |
 | `schema:function:hl7v2.ops.purge:input` / `:output` | `ops/purge` I/O |
 
-The catalog token is always `hl7v2`. The schema slot is `v251`, `v25`, … for
+The catalog token is always `hl7v2`. The schema slot is `v27`, `v25`, … for
 HL7-spec content; for extensions, it's a namespace the extension package
 declares (`epic`, `cerner`, `nhs-uk`, `local`). This is an internal addressing
 convention only — the module keeps the namespaces from colliding (below); there
 is no platform-level "namespace ownership" rule. Names mirror HAPI's
-structure-class names — `ADT_A01`, `PID`, `CX`, `HL70001`.
+structure-class names — `ADT_A01`, `PID`, `CX`, `HL70203`.
 
 Extension packages contribute schemas in **their own namespace**.
 There's no merging into base schemas — `schema:type:hl7v2.epic.ZPV` and
-`schema:type:hl7v2.v251.PID` coexist as peers. A message structure that
+`schema:type:hl7v2.v27.PID` coexist as peers. A message structure that
 includes Z-segments is a *new* schema in the extension's namespace
 (e.g. `schema:table:hl7v2.epic.ADT_A01_with_ZPV`), referencing the base
 segments plus the Z-segment. Collisions are impossible by construction;
@@ -133,7 +133,7 @@ HL7 is composition-heavy. A worked traversal:
 
 ```yaml
 Schema:
-  id: schema:table:hl7v2.v251.ADT_A01
+  id: schema:table:hl7v2.v27.ADT_A01
   dataTypes:
     - { name: string }
     - { name: date-time }
@@ -141,18 +141,18 @@ Schema:
     - name: msh
       required: true
       references:
-        schemaId: schema:type:hl7v2.v251.MSH
+        schemaId: schema:type:hl7v2.v27.MSH
     - name: evn
       required: true
       references:
-        schemaId: schema:type:hl7v2.v251.EVN
+        schemaId: schema:type:hl7v2.v27.EVN
     - name: pid
       required: true
       references:
-        schemaId: schema:type:hl7v2.v251.PID
+        schemaId: schema:type:hl7v2.v27.PID
     - name: pv1
       references:
-        schemaId: schema:type:hl7v2.v251.PV1
+        schemaId: schema:type:hl7v2.v27.PV1
     # ... and the envelope fields from the shared schema:
     - name: controlId
       dataType: string
@@ -167,28 +167,27 @@ Schema:
         schemaId: schema:enum:hl7v2.ops.MessageStatus    # new | in_flight | acked
 
 Schema:
-  id: schema:type:hl7v2.v251.PID
+  id: schema:type:hl7v2.v27.PID
   dataTypes: [{ name: string }, { name: date-time }]
   properties:
     - name: patientIdentifierList
       multi: true
       required: true
       references:
-        schemaId: schema:type:hl7v2.v251.CX
+        schemaId: schema:type:hl7v2.v27.CX
     - name: patientName
       multi: true
       required: true
       references:
-        schemaId: schema:type:hl7v2.v251.XPN
+        schemaId: schema:type:hl7v2.v27.XPN
     - name: dateOfBirth
-      dataType: date-time
+      dataType: date-time          # DTM primitive in v2.7 (v2.5.1's TS composite retired)
     - name: administrativeSex
-      dataType: string
-      references:
-        schemaId: schema:enum:hl7v2.v251.HL70001
+      references:                   # CWE composite in v2.7 (v2.5.1's IS+table HL70001 retired)
+        schemaId: schema:type:hl7v2.v27.CWE
 
 Schema:
-  id: schema:type:hl7v2.v251.CX
+  id: schema:type:hl7v2.v27.CX
   dataTypes: [{ name: string }]
   properties:
     - name: idNumber
@@ -196,14 +195,14 @@ Schema:
       required: true
     - name: assigningAuthority
       references:
-        schemaId: schema:type:hl7v2.v251.HD
+        schemaId: schema:type:hl7v2.v27.HD
     - name: identifierTypeCode
       dataType: string
       references:
-        schemaId: schema:enum:hl7v2.v251.HL70203
+        schemaId: schema:enum:hl7v2.v27.HL70203
 ```
 
-A consumer walking from `schema:table:hl7v2.v251.ADT_A01` discovers
+A consumer walking from `schema:table:hl7v2.v27.ADT_A01` discovers
 the full bean graph (MSH → PID → CX → HD → HL70203 enum), caches each
 `getSchema` response, and ends up with the same typed view a HAPI Java
 client gets from `msg.getPID().getPatientIdentifierList(0).getAssigningAuthority().getNamespaceId()`.
@@ -222,9 +221,9 @@ never `dataType: string + format: <thing>` when a core type exists.
 | DT (`YYYYMMDD`) | `date` | Producer normalizes to ISO 8601 at materialization. |
 | TM (`HHMMSS[.s+/-ZZZZ]`) | `string` | No core "time-only" type; `format: time` hint. |
 | DTM / TS (`YYYYMMDDHHMMSS[.s][+/-ZZZZ]`) | `date-time` | Normalized to ISO 8601. |
-| EI (entity identifier) | composition `references` to `schema:type:hl7v2.v251.EI` | |
-| HD, CX, XPN, XAD, CE, CWE, CNE, CWE, … | composition `references` to `schema:type:hl7v2.v251.<name>` | Each composite gets its own schema. |
-| Repeating fields | parent property + `multi: true` | E.g. `patientName: { multi: true, references: schemaId: schema:type:hl7v2.v251.XPN }`. |
+| EI (entity identifier) | composition `references` to `schema:type:hl7v2.v27.EI` | |
+| HD, CX, XPN, XAD, CE, CWE, CNE, CWE, … | composition `references` to `schema:type:hl7v2.v27.<name>` | Each composite gets its own schema. |
+| Repeating fields | parent property + `multi: true` | E.g. `patientName: { multi: true, references: schemaId: schema:type:hl7v2.v27.XPN }`. |
 
 The producer normalizes wire-format values at materialization time —
 ETL never sees HL7 date formats, never has to re-parse pipe-encoded
@@ -547,8 +546,8 @@ with extension-supplied entries (see §7).
 generic-parsed:  PID|||5551212^^^EPIC&...^MR||SMITH^JOHN||19800101|M
 structure idx :  PID-3 patientIdentifierList CX[] required
                  PID-5 patientName XPN[] required
-                 PID-7 dateOfBirth DTM optional
-                 PID-8 administrativeSex IS optional table=HL70001
+                 PID-7 dateTimeOfBirth DTM optional (primitive in v2.7)
+                 PID-8 administrativeSex CWE optional (composite in v2.7)
 materializer →
 {
   "patientIdentifierList": [
@@ -559,8 +558,8 @@ materializer →
   "patientName": [
     { "familyName": { "surname": "SMITH" }, "givenName": "JOHN" }
   ],
-  "dateOfBirth": "1980-01-01T00:00:00Z",
-  "administrativeSex": "M"
+  "dateOfBirth": "1980-01-01",
+  "administrativeSex": { "identifier": "M" }
 }
 ```
 
@@ -575,8 +574,10 @@ consumer follows the `schema:enum:…` reference to get display values).
 > (`idNumber`, `surname`, `dateOfBirth: …T00:00:00Z`) are **illustrative**. The
 > actual materialized keys are HAPI's bean names — `IDNumber`, `namespaceID`,
 > `dateTimeOfBirth`, etc. — and they match the generated schemas exactly (both come
-> from the same structure index). Two real consequences: `TS` is a *composite* in
-> v2.5.1, so timestamps nest under `time` (`dateTimeOfBirth.time`); and dates are
+> from the same structure index). Two real consequences for v2.7: `DTM` is a
+> *primitive*, so `dateTimeOfBirth` is a flat string (v2.5.1's `TS` composite that
+> nested under `time` was retired), and `administrativeSex` is a `CWE` *composite*
+> (the bare code lands in `identifier`, e.g. `{"identifier":"M"}`); and dates are
 > precision-preserving (no fabricated midnight/zone) per the validated
 > `Hl7Normalizer`. Treat the generated schema as the contract, not this example.
 
@@ -594,12 +595,12 @@ java/
 ├── src/main/
 │   ├── java/...                                   # listener + materializer + buffer
 │   └── resources/
-│       ├── schemas/v251/
-│       │   ├── messages/ADT_A01.json              # schema:table:hl7v2.v251.ADT_A01
-│       │   ├── segments/PID.json                  # schema:type:hl7v2.v251.PID
-│       │   ├── datatypes/CX.json                  # schema:type:hl7v2.v251.CX
-│       │   └── tables/HL70001.json                # schema:enum:hl7v2.v251.HL70001
-│       └── structure-index/v251.json              # runtime materializer driver
+│       ├── schemas/v27/
+│       │   ├── messages/ADT_A01.json              # schema:table:hl7v2.v27.ADT_A01
+│       │   ├── segments/PID.json                  # schema:type:hl7v2.v27.PID
+│       │   ├── datatypes/CX.json                  # schema:type:hl7v2.v27.CX
+│       │   └── tables/HL70203.json                # schema:enum:hl7v2.v27.HL70203
+│       └── structure-index/v27.json              # runtime materializer driver
 └── pom.xml                                        # exec-maven-plugin: runs codegen before package
 ```
 
@@ -662,7 +663,7 @@ platform-parsed identity.
   "version": "1.2.4",
   "auditmation": {
     "hl7": {
-      "version": "2.5.1",
+      "version": "2.7",
       "vendor": "epic",
       "namespace": "epic",
       "messageGroups": ["ADT"]
@@ -687,7 +688,7 @@ standard parsed name, with no namespace-subpath rule.
 
 Extensions don't modify base schemas. They contribute *new* schemas
 under their own namespace. `schema:table:hl7v2.epic.ADT_A01_with_ZPV`
-references base segments from `hl7v2.v251.*` plus its own ZPV segment:
+references base segments from `hl7v2.v27.*` plus its own ZPV segment:
 
 ```yaml
 Schema:
@@ -696,24 +697,24 @@ Schema:
   dataTypes: [...]
   properties:
     - name: msh
-      references: { schemaId: schema:type:hl7v2.v251.MSH }       # base
+      references: { schemaId: schema:type:hl7v2.v27.MSH }       # base
     - name: pid
-      references: { schemaId: schema:type:hl7v2.v251.PID }       # base
+      references: { schemaId: schema:type:hl7v2.v27.PID }       # base
     - name: pv1
-      references: { schemaId: schema:type:hl7v2.v251.PV1 }       # base
+      references: { schemaId: schema:type:hl7v2.v27.PV1 }       # base
     - name: zpv
       references: { schemaId: schema:type:hl7v2.epic.ZPV }       # extension
     # ... plus envelope fields
 ```
 
-Collisions impossible — `epic.ADT_A01_with_ZPV` and `v251.ADT_A01` are
+Collisions impossible — `epic.ADT_A01_with_ZPV` and `v27.ADT_A01` are
 peer schemas in the module's in-memory schema registry (not the platform catalog).
 
 The receiver's hierarchy reflects what's loaded. With the Epic extension
 pulled in, `/hl7-v2-receiver/by-type` lists both:
 
 ```
-/hl7-v2-receiver/by-type/ADT_A01              ← base, schema:table:hl7v2.v251.ADT_A01
+/hl7-v2-receiver/by-type/ADT_A01              ← base, schema:table:hl7v2.v27.ADT_A01
 /hl7-v2-receiver/by-type/ADT_A01_with_ZPV     ← extension, schema:table:hl7v2.epic.ADT_A01_with_ZPV
 ```
 
@@ -964,8 +965,8 @@ PLATFORM_UPDATES.md §8.
    module's root `runtimeConfig.yml` → `module_version.runtime_config`
    (PLATFORM_UPDATES §6.3).
 3. **Build-time schema codegen.** Maven sub-module that walks
-   `hapi-structures-v251`, emits `schemas/v251/*.json` and
-   `structure-index/v251.json`. Standalone — verifiable against the
+   `hapi-structures-v27`, emits `schemas/v27/*.json` and
+   `structure-index/v27.json`. Standalone — verifiable against the
    spec without the rest of the module.
 4. **Materializer + buffer + producer in isolation.** Unit tests:
    synthetic MLLP client → assert buffer rows + typed JSON shape +

--- a/package/hl7/v2/PLAN.md
+++ b/package/hl7/v2/PLAN.md
@@ -1,5 +1,13 @@
 # Build Plan — `@zerobias-org/module-hl7-v2`
 
+> **Status note (2026-06-04).** Module now targets **HL7 v2.7** (was v2.5.1): codegen
+> pulls `hapi-structures-v27`, the runtime structure slot is **config-driven** from
+> `runtimeConfig.config.hl7Version` (default `2.7` → `v27`, no longer hardcoded), and
+> the MLLP listener port is prescribed `2575`. Also fixed: paginated producer ops now
+> return the `PagedResults` envelope (`{items,count,pageSize,pageNumber}`) the
+> data-explorer requires. v2.7 datatype shifts captured in tests/DESIGN (DTM primitive,
+> CWE administrativeSex). Historical phase notes below predate this and may say `v251`.
+
 Module-side implementation plan. Owner: Daniel. Platform updates
 (daemon mode, listener ports, durability, opaque `config` passthrough) are
 owned separately — see [`PLATFORM_UPDATES.md`](PLATFORM_UPDATES.md) — and this
@@ -223,10 +231,11 @@ Legend: 🟢 fully independent · 🔵 needs a contract seam agreed · 🔴 bloc
   ADT^A01, asserts AA + echoed control id, the buffered row's envelope +
   normalized JSON (`dateOfBirth: 1980-01-01`), and duplicate dedup. Also
   runnable by hand: `java/scripts/manual-test.sh listener`.
-- **Deferred (not blocking):** `MetricsConnectionListener`; mapping
-  `connectionProfile.hl7Version` → schema slot (hardcoded `v251` for now);
+- **Deferred (not blocking):** `MetricsConnectionListener`;
   the `MSA|AE` failure path is implemented but not yet unit-tested; reading the
   port from `LISTENER_PORT_MLLP` env happens in `Hl7ApiServer` wiring (Phase 6).
+  (The `hl7Version` → schema slot mapping is now config-driven via
+  `runtimeConfig.config.hl7Version`, default `2.7` → `v27` — see post-2026-06-04 note.)
 
 ### Phase 5 — lite-filter SQL adapter 🟢 ✅ *(done & validated 2026-05-29)*
 - ✅ `filter/Hl7SqlAdapter` — NOT a verbatim lift. The SQL module's

--- a/package/hl7/v2/README.md
+++ b/package/hl7/v2/README.md
@@ -134,7 +134,7 @@ durability:
       retention: { maxBytes: 10737418240, maxAge: P7D } }
 config:                                            # opaque to the platform (MODULE_CONFIG)
   activeExtensions: []                             # empty = all baked-in packs
-  hl7Version: "2.5.1"
+  hl7Version: "2.7"
 ```
 
 The Hub Node injects `LISTENER_PORT_MLLP`, maps the port 1:1 (no NAT), mounts the
@@ -149,7 +149,7 @@ is no remote system to dial):
 
 | Field | Meaning |
 |---|---|
-| `hl7Version` | target version for materialization (default `2.5.1`) |
+| `hl7Version` | target version for materialization (default `2.7`) |
 | `ackDurability` | `normal` (fsync at WAL checkpoint) or `full` (fsync per row, zero-loss) |
 | `backpressurePolicy` | what to do when the buffer fills — default `reject` (`MSA|AE`, sender retries) |
 | `senderDiscriminator` | `/by-sender` key — default MSH-3 |

--- a/package/hl7/v2/connectionProfile.yml
+++ b/package/hl7/v2/connectionProfile.yml
@@ -13,10 +13,14 @@ properties:
     description: >-
       Target HL7 v2 version. The receiver accepts other versions
       (HAPI allowUnknownVersions) but materializes typed JSON against this
-      version's structure index. Mismatched feeds produce partially-populated
-      JSON, surfaced per-message via the envelope. (DESIGN §11.5)
-    default: "2.5.1"
-    example: "2.5.1"
+      version's baked-in structure index (2.7 -> v27). Mismatched feeds produce
+      partially-populated JSON, surfaced per-message via the envelope.
+      NOTE: like ackDurability, the materializer is daemon-wide (one buffer, one
+      listener), so the receiver takes its EFFECTIVE version from
+      runtimeConfig.config.hl7Version (MODULE_CONFIG), set at container boot —
+      not from this per-connection field. (DESIGN §11.5)
+    default: "2.7"
+    example: "2.7"
   ackDurability:
     type: string
     description: >-

--- a/package/hl7/v2/gate-stamp.json
+++ b/package/hl7/v2/gate-stamp.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.1.0-uat.0",
-  "branch": "chore/hl7-v2-version-1.1.0",
+  "version": "1.2.0-uat.0",
+  "branch": "hl7",
   "sourceHash": "ee53f317cdbe90a30f2a1e0113a17cf3101735b0302a4667360f92e2d70aac09",
   "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "tasks": {

--- a/package/hl7/v2/java/codegen/pom.xml
+++ b/package/hl7/v2/java/codegen/pom.xml
@@ -11,7 +11,7 @@
 
     mvn -f codegen/pom.xml compile exec:java \
         -Dexec.mainClass=com.zerobias.module.hl7.codegen.SchemaGenerator \
-        -Dexec.args="v251 ../src/main/resources"
+        -Dexec.args="v27 ../src/main/resources"
 
   This is the ONLY place hapi-structures-vNN jars are pulled — they never ship
   in the runtime uber JAR.
@@ -44,11 +44,12 @@
             <artifactId>hapi-base</artifactId>
             <version>${hapi.version}</version>
         </dependency>
-        <!-- The typed model classes the generator reflects over. Add more
-             versions here (hapi-structures-v25, -v23, ...) as we support them. -->
+        <!-- The typed model classes the generator reflects over. The module targets
+             HL7 v2.7 (ca.uhn.hl7v2.model.v27.*); add more versions here
+             (hapi-structures-v251, -v25, ...) if we re-introduce them. -->
         <dependency>
             <groupId>ca.uhn.hapi</groupId>
-            <artifactId>hapi-structures-v251</artifactId>
+            <artifactId>hapi-structures-v27</artifactId>
             <version>${hapi.version}</version>
         </dependency>
         <dependency>
@@ -83,8 +84,8 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.1.2</version>
             </plugin>
-            <!-- StructureWalkerIT walks HAPI's typed v251 structures (the build-time-only
-                 hapi-structures-v251 dep), so it is a failsafe (*IT) test. The parent
+            <!-- StructureWalkerIT walks HAPI's typed v27 structures (the build-time-only
+                 hapi-structures-v27 dep), so it is a failsafe (*IT) test. The parent
                  java/pom.xml drives `mvn -f codegen/pom.xml verify` during its own test
                  phase so this actually runs in the gate (DESIGN §6 codegen boundary). -->
             <plugin>

--- a/package/hl7/v2/java/codegen/src/main/java/com/zerobias/module/hl7/codegen/SchemaGenerator.java
+++ b/package/hl7/v2/java/codegen/src/main/java/com/zerobias/module/hl7/codegen/SchemaGenerator.java
@@ -35,7 +35,7 @@ import java.util.Set;
  * {@code regen-schemas} profile). PLAN.md Phase 1.
  *
  * <p>Usage: {@code SchemaGenerator <version> <outputDir> [msg...]}
- * (e.g. {@code SchemaGenerator v251 ../src/main/resources ADT_A01 ORU_R01}).
+ * (e.g. {@code SchemaGenerator v27 ../src/main/resources ADT_A01 ORU_R01}).
  * With no message list, a small default set is generated; expand it to widen
  * coverage (the walk discovers all transitively-referenced structures).
  */
@@ -59,7 +59,7 @@ public final class SchemaGenerator {
     public static void main(String[] args) throws Exception {
         if (args.length < 2) {
             System.err.println("usage: SchemaGenerator <version> <outputDir> [msg...]"
-                + "  (e.g. v251 ../src/main/resources ADT_A01 ORU_R01)");
+                + "  (e.g. v27 ../src/main/resources ADT_A01 ORU_R01)");
             System.exit(2);
             return;
         }

--- a/package/hl7/v2/java/codegen/src/main/java/com/zerobias/module/hl7/codegen/SchemaIds.java
+++ b/package/hl7/v2/java/codegen/src/main/java/com/zerobias/module/hl7/codegen/SchemaIds.java
@@ -8,7 +8,7 @@ import java.util.regex.Pattern;
  *
  * <p>Form: {@code schema:{type}:{catalog}.{schema}.{name}[:{direction}]}. For HL7
  * the catalog token is always {@code hl7v2} and the schema slot is the version
- * (e.g. {@code v251}) for spec content, or an extension namespace (e.g. {@code epic}).
+ * (e.g. {@code v27}) for spec content, or an extension namespace (e.g. {@code epic}).
  */
 public final class SchemaIds {
 

--- a/package/hl7/v2/java/codegen/src/test/java/com/zerobias/module/hl7/codegen/PureHelpersTest.java
+++ b/package/hl7/v2/java/codegen/src/test/java/com/zerobias/module/hl7/codegen/PureHelpersTest.java
@@ -16,14 +16,14 @@ class PureHelpersTest {
 
     @Test
     void schemaIds() {
-        assertEquals("schema:table:hl7v2.v251.ADT_A01", SchemaIds.table("v251", "ADT_A01"));
-        assertEquals("schema:type:hl7v2.v251.PID", SchemaIds.type("v251", "PID"));
-        assertEquals("schema:enum:hl7v2.v251.HL70001", SchemaIds.enumTable("v251", 1));
-        assertEquals("schema:enum:hl7v2.v251.HL70203", SchemaIds.enumTable("v251", 203));
+        assertEquals("schema:table:hl7v2.v27.ADT_A01", SchemaIds.table("v27", "ADT_A01"));
+        assertEquals("schema:type:hl7v2.v27.PID", SchemaIds.type("v27", "PID"));
+        assertEquals("schema:enum:hl7v2.v27.HL70001", SchemaIds.enumTable("v27", 1));
+        assertEquals("schema:enum:hl7v2.v27.HL70203", SchemaIds.enumTable("v27", 203));
         assertEquals("schema:shared:hl7v2.message-envelope", SchemaIds.shared("hl7v2.message-envelope"));
 
-        assertTrue(SchemaIds.isValid("schema:table:hl7v2.v251.ADT_A01"));
-        assertTrue(SchemaIds.isValid("schema:enum:hl7v2.v251.HL70001"));
+        assertTrue(SchemaIds.isValid("schema:table:hl7v2.v27.ADT_A01"));
+        assertTrue(SchemaIds.isValid("schema:enum:hl7v2.v27.HL70001"));
         assertTrue(SchemaIds.isValid("schema:shared:hl7v2.message-envelope"));
         assertFalse(SchemaIds.isValid("table:foo"));
     }

--- a/package/hl7/v2/java/codegen/src/test/java/com/zerobias/module/hl7/codegen/StructureWalkerIT.java
+++ b/package/hl7/v2/java/codegen/src/test/java/com/zerobias/module/hl7/codegen/StructureWalkerIT.java
@@ -10,11 +10,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Acceptance test for Phase 1 (PLAN.md): walks {@code ADT_A01} against HAPI's
- * v2.5.1 structures and asserts the worked traversal from DESIGN §2.3 —
+ * v2.7 structures and asserts the worked traversal from DESIGN §2.3 —
  * {@code ADT_A01 → PID → CX → HD}, with the table-bound enum references
- * (administrative sex → HL70001, identifier type code → HL70203).
+ * (PID indicator fields → HL70136, identifier type code → HL70203). NB: in
+ * v2.7 PID-8 administrativeSex became a CWE composite (no longer the IS+HL70001
+ * of v2.5.1), so the low-number worked example is HL70136, not HL70001.
  *
- * <p>Requires {@code hapi-structures-v251} on the test classpath (it is a
+ * <p>Requires {@code hapi-structures-v27} on the test classpath (it is a
  * dependency of the codegen module), so it runs only under the build toolchain,
  * not the toolchain-independent {@link PureHelpersTest}.
  */
@@ -22,7 +24,7 @@ class StructureWalkerIT {
 
     @Test
     void walksAdtA01ToEnumLeaves() throws Exception {
-        final StructureWalker w = new StructureWalker("v251");
+        final StructureWalker w = new StructureWalker("v27");
         w.walkMessage("ADT_A01");
 
         // Structures discovered transitively.
@@ -40,25 +42,25 @@ class StructureWalkerIT {
         // ADT_A01 references the PID segment by composition.
         final Property pidProp = prop(w.messages.get("ADT_A01"), "pid");
         assertNotNull(pidProp, "ADT_A01.pid property");
-        assertEquals(SchemaIds.type("v251", "PID"), pidProp.references.schemaId);
+        assertEquals(SchemaIds.type("v27", "PID"), pidProp.references.schemaId);
 
         // PID.patientIdentifierList is a repeating CX composition (DESIGN §2.3).
         final Property pidList = prop(w.segments.get("PID"), "patientIdentifierList");
         assertNotNull(pidList, "PID.patientIdentifierList property");
         assertEquals(Boolean.TRUE, pidList.multi);
-        assertEquals(SchemaIds.type("v251", "CX"), pidList.references.schemaId);
+        assertEquals(SchemaIds.type("v27", "CX"), pidList.references.schemaId);
 
         // CX composes HD (assigning authority) and carries an HL70203 enum reference.
         final Schema cx = w.datatypes.get("CX");
         assertTrue(cx.properties.stream().anyMatch(p ->
-                p.references != null && SchemaIds.type("v251", "HD").equals(p.references.schemaId)),
+                p.references != null && SchemaIds.type("v27", "HD").equals(p.references.schemaId)),
             "CX references HD");
         assertTrue(cx.properties.stream().anyMatch(p ->
-                p.references != null && SchemaIds.enumTable("v251", 203).equals(p.references.schemaId)),
+                p.references != null && SchemaIds.enumTable("v27", 203).equals(p.references.schemaId)),
             "CX references enum HL70203");
 
-        // Table-bound fields registered the enums (HL70001 admin sex, HL70203 id type).
-        assertTrue(w.tables.contains(1), "table HL70001 registered");
+        // Table-bound fields registered the enums (HL70136 PID indicators, HL70203 id type).
+        assertTrue(w.tables.contains(136), "table HL70136 registered");
         assertTrue(w.tables.contains(203), "table HL70203 registered");
 
         // Guard: HAPI exposes repetition-count getters (e.g.

--- a/package/hl7/v2/java/pom.xml
+++ b/package/hl7/v2/java/pom.xml
@@ -107,7 +107,7 @@
                  produced on every build: otherwise the shaded jar ships with no schemas
                  and the producer/getSchema/by-type surface + materializer silently
                  degrade. Runs the codegen submodule (which carries the build-time-only
-                 hapi-structures-v251 dep). -->
+                 hapi-structures-v27 dep). -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
@@ -127,7 +127,7 @@
                                 <argument>compile</argument>
                                 <argument>exec:java</argument>
                                 <argument>-Dexec.mainClass=com.zerobias.module.hl7.codegen.SchemaGenerator</argument>
-                                <argument>-Dexec.args=v251 ${project.basedir}/src/main/resources</argument>
+                                <argument>-Dexec.args=v27 ${project.basedir}/src/main/resources</argument>
                             </arguments>
                         </configuration>
                     </execution>

--- a/package/hl7/v2/java/scripts/e2e-local.sh
+++ b/package/hl7/v2/java/scripts/e2e-local.sh
@@ -50,7 +50,7 @@ python3 - "$MLLP" <<'PY'
 import socket, sys
 port = int(sys.argv[1])
 msg = "\r".join([
-    "MSH|^~\\&|EPIC|HOSP|RECV|DEST|20260601120000||ADT^A01^ADT_A01|MSG-E2E-1|P|2.5.1",
+    "MSH|^~\\&|EPIC|HOSP|RECV|DEST|20260601120000||ADT^A01^ADT_A01|MSG-E2E-1|P|2.7",
     "EVN|A01|20260601120000",
     "PID|1||5551212^^^EPIC^MR||DOE^JANE||19850315|F",
     "PV1|1|I",

--- a/package/hl7/v2/java/scripts/hl7-live.sh
+++ b/package/hl7/v2/java/scripts/hl7-live.sh
@@ -55,7 +55,7 @@ port=int(sys.argv[1]); fam=sys.argv[2]; giv=sys.argv[3]
 cid="MSG-"+str(int(time.time()*1000))
 mrn=cid[-7:]
 msg="\r".join([
-  f"MSH|^~\\&|EPIC|HOSP|RECV|DEST|20260601120000||ADT^A01^ADT_A01|{cid}|P|2.5.1",
+  f"MSH|^~\\&|EPIC|HOSP|RECV|DEST|20260601120000||ADT^A01^ADT_A01|{cid}|P|2.7",
   "EVN|A01|20260601120000",
   f"PID|1||{mrn}^^^EPIC^MR||{fam}^{giv}||19850315|F",
   "PV1|1|I"]) + "\r"

--- a/package/hl7/v2/java/scripts/synthea_to_mllp.py
+++ b/package/hl7/v2/java/scripts/synthea_to_mllp.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+# ─────────────────────────────────────────────────────────────────────────────
+# DEV / LOCAL TOOL — NOT part of the build or CI gate, and nothing references it.
+# The standardized test surface is the JUnit suite under java/src/test, run by the
+# real gate:  ./gradlew :hl7:v2:gate  (see CLAUDE.md). A convenience for feeding the
+# listener real-shaped data; safe to delete.
+# ─────────────────────────────────────────────────────────────────────────────
+"""
+Stream real Synthea patient data into this module's HL7 v2 MLLP listener.
+
+Synthea emits FHIR (not HL7 v2), so this reads Synthea's FHIR transaction
+bundles (output/fhir/*.json), builds HL7 v2.7 messages from the real
+Patient / Encounter / Observation resources, frames them in MLLP
+(0x0B <msg> 0x1C 0x0D), sends each to the listener, and prints the ACK.
+
+  ADT^A01  (admit)  — one per patient, from Patient + first Encounter
+  ORU^R01  (result) — optional (--oru), one per numeric Observation
+
+Usage:
+  ./run_synthea -p 5            # in ~/synthea — generates output/fhir/*.json
+  python3 synthea_to_mllp.py --fhir-dir ~/synthea/output/fhir
+  python3 synthea_to_mllp.py --fhir-dir ~/synthea/output/fhir --oru --limit 3
+  python3 synthea_to_mllp.py --dry-run                 # print, don't send
+
+Default target is localhost:2575 (the prescribed runtimeConfig MLLP port,
+published to the host via MODULE_PORTS in the dev appliance). Stdlib only.
+"""
+import argparse, glob, json, os, socket, sys, time
+
+VT, FS, CR = b"\x0b", b"\x1c", b"\x0d"
+
+
+def ts(fhir_dt=None):
+    """FHIR dateTime (or now) -> HL7 TS (YYYYMMDDHHMMSS / YYYYMMDD)."""
+    if fhir_dt:
+        digits = "".join(c for c in fhir_dt if c.isdigit())
+        if len(digits) >= 14:
+            return digits[:14]
+        if len(digits) >= 8:
+            return digits[:8]
+    return time.strftime("%Y%m%d%H%M%S")
+
+
+def esc(s):
+    """Escape HL7 delimiter chars in a component value."""
+    if s is None:
+        return ""
+    s = str(s)
+    for a, b in (("\\", "\\E\\"), ("|", "\\F\\"), ("^", "\\S\\"), ("~", "\\R\\"), ("&", "\\T\\")):
+        s = s.replace(a, b)
+    return s
+
+
+def find(bundle, rtype):
+    for e in bundle.get("entry", []):
+        r = e.get("resource", {})
+        if r.get("resourceType") == rtype:
+            yield r
+
+
+def mrn(patient):
+    for ident in patient.get("identifier", []):
+        for c in ident.get("type", {}).get("coding", []):
+            if c.get("code") == "MR":
+                return ident.get("value", "")
+    ids = patient.get("identifier", [])
+    return ids[0].get("value", "") if ids else patient.get("id", "")
+
+
+def pid_segment(patient):
+    name = (patient.get("name") or [{}])[0]
+    family = esc(name.get("family", ""))
+    given = "^".join(esc(g) for g in name.get("given", []))
+    sex = {"male": "M", "female": "F"}.get(patient.get("gender", ""), "U")
+    dob = ts(patient.get("birthDate"))[:8]
+    addr = (patient.get("address") or [{}])[0]
+    line = esc((addr.get("line") or [""])[0])
+    xad = f"{line}^^{esc(addr.get('city',''))}^{esc(addr.get('state',''))}^{esc(addr.get('postalCode',''))}"
+    return f"PID|1||{esc(mrn(patient))}^^^HOSP^MR||{family}^{given}||{dob}|{sex}|||{xad}"
+
+
+PATIENT_CLASS = {"IMP": "I", "ACUTE": "I", "AMB": "O", "EMER": "E", "OBSENC": "O", "SS": "O"}
+
+
+def pv1_segment(encounter):
+    cls = (encounter or {}).get("class", {}).get("code", "AMB")
+    pc = PATIENT_CLASS.get(cls, "O")
+    start = ts((encounter or {}).get("period", {}).get("start"))
+    return f"PV1|1|{pc}|^^^HOSP|||||||||||||||||{start}"
+
+
+HL7_VERSION = "2.7"
+
+
+def msh(msg_type, ctrl_id, when=None):
+    return f"MSH|^~\\&|SYNTHEA|SYNTHEA|HUB|ZB|{when or ts()}||{msg_type}|{ctrl_id}|P|{HL7_VERSION}"
+
+
+def build_adt(patient, encounter, ctrl):
+    when = ts((encounter or {}).get("period", {}).get("start"))
+    return "\r".join([
+        msh("ADT^A01", ctrl, when),
+        f"EVN|A01|{when}",
+        pid_segment(patient),
+        pv1_segment(encounter),
+    ])
+
+
+def build_oru(patient, obs, ctrl):
+    code = (obs.get("code", {}).get("coding") or [{}])[0]
+    obs_id = esc(code.get("code", ""))
+    obs_name = esc(code.get("display", ""))
+    when = ts(obs.get("effectiveDateTime"))
+    vq = obs.get("valueQuantity", {})
+    return "\r".join([
+        msh("ORU^R01", ctrl, when),
+        pid_segment(patient),
+        f"OBR|1|||{obs_id}^{obs_name}^LN|||{when}",
+        f"OBX|1|NM|{obs_id}^{obs_name}^LN||{vq.get('value','')}|{esc(vq.get('unit',''))}|||||F",
+    ])
+
+
+def mllp_send(host, port, message, timeout=10):
+    frame = VT + message.encode("utf-8") + FS + CR
+    with socket.create_connection((host, port), timeout=timeout) as s:
+        s.sendall(frame)
+        ack = b""
+        while FS not in ack:
+            chunk = s.recv(65536)
+            if not chunk:
+                break
+            ack += chunk
+    return ack.replace(VT, b"").replace(FS, b"").replace(CR, b"\n").decode(errors="replace").strip()
+
+
+def ack_code(ack):
+    for line in ack.splitlines():
+        if line.startswith("MSA"):
+            f = line.split("|")
+            return f[1] if len(f) > 1 else "?"
+    return "?"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--fhir-dir", default=os.path.expanduser("~/synthea/output/fhir"))
+    ap.add_argument("--host", default="localhost")
+    ap.add_argument("--port", type=int, default=2575)
+    ap.add_argument("--limit", type=int, default=0, help="max patients (0 = all)")
+    ap.add_argument("--oru", action="store_true", help="also send ORU^R01 per numeric Observation")
+    ap.add_argument("--oru-max", type=int, default=5, help="max ORU per patient")
+    ap.add_argument("--dry-run", action="store_true", help="print messages, don't send")
+    args = ap.parse_args()
+
+    files = sorted(glob.glob(os.path.join(args.fhir_dir, "*.json")))
+    files = [f for f in files if not os.path.basename(f).lower().startswith(("hospital", "practitioner"))]
+    if not files:
+        sys.exit(f"No FHIR bundles in {args.fhir_dir} — run `./run_synthea -p 5` in ~/synthea first.")
+
+    sent = acks = pcount = 0
+    ctrl = int(time.time())
+    for f in files:
+        if args.limit and pcount >= args.limit:
+            break
+        try:
+            bundle = json.load(open(f))
+        except Exception as e:
+            print(f"skip {os.path.basename(f)}: {e}")
+            continue
+        patients = list(find(bundle, "Patient"))
+        if not patients:
+            continue
+        patient = patients[0]
+        pcount += 1
+        encounters = list(find(bundle, "Encounter"))
+        name = (patient.get("name") or [{}])[0]
+        who = f"{(name.get('given') or [''])[0]} {name.get('family','')}".strip()
+
+        ctrl += 1
+        adt = build_adt(patient, encounters[0] if encounters else None, f"S{ctrl}")
+        if args.dry_run:
+            print(f"--- ADT^A01 {who} ---\n{adt.replace(chr(13), chr(10))}\n")
+        else:
+            try:
+                code = ack_code(mllp_send(args.host, args.port, adt))
+                sent += 1
+                acks += 1 if code.startswith("A") else 0
+                print(f"ADT^A01  {who:<28} -> {code}")
+            except Exception as e:
+                print(f"ADT^A01  {who:<28} -> SEND FAILED: {e}")
+
+        if args.oru:
+            obs = [o for o in find(bundle, "Observation") if "valueQuantity" in o][: args.oru_max]
+            for o in obs:
+                ctrl += 1
+                oru = build_oru(patient, o, f"S{ctrl}")
+                if args.dry_run:
+                    print(f"--- ORU^R01 {who} ---\n{oru.replace(chr(13), chr(10))}\n")
+                else:
+                    try:
+                        ack_code(mllp_send(args.host, args.port, oru))
+                        sent += 1
+                    except Exception as e:
+                        print(f"ORU^R01  {who:<28} -> SEND FAILED: {e}")
+
+    if not args.dry_run:
+        print(f"\nSent {sent} message(s), {acks} ADT accepted (MSA|AA).")
+
+
+if __name__ == "__main__":
+    main()

--- a/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/Hl7ApiServer.java
+++ b/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/Hl7ApiServer.java
@@ -59,8 +59,6 @@ public final class Hl7ApiServer {
 
     private static final Logger LOG = LoggerFactory.getLogger(Hl7ApiServer.class);
     private static final Gson GSON = new Gson();
-    private static final String VERSION_SLOT = "v251";
-    private static final String HL7_VERSION = "2.5.1";
 
     /** Profile fields safe to log/display (no secrets in this receiver profile). */
     private static final Set<String> NONSENSITIVE_PROFILE_FIELDS =
@@ -90,6 +88,11 @@ public final class Hl7ApiServer {
         // module. They configure the buffer at boot, before any connection exists, so
         // they cannot come from the per-connection connectionProfile. (DESIGN §3.2, §8)
         ModuleRuntimeConfig mc = ModuleRuntimeConfig.fromEnv();
+        // Target HL7 version drives which baked-in structure index materializes the
+        // typed JSON (DESIGN §11.5). The slot is HAPI's vNN package name (2.7 -> v27).
+        final String hl7Version = mc.hl7Version();
+        final String versionSlot = mc.versionSlot();
+        LOG.info("Target HL7 version: {} (structure slot {})", hl7Version, versionSlot);
 
         // --- daemon: buffer + MLLP listener (DESIGN §4) ---
         String dbPath = System.getenv().getOrDefault("BUFFER_DB", "/var/lib/module/buffer.db");
@@ -115,13 +118,13 @@ public final class Hl7ApiServer {
             Path schemaRoot = Path.of(System.getenv().getOrDefault("SCHEMA_DIR", "/opt/module/generated"));
             schemas = SchemaRegistry.fromDirectory(schemaRoot);
         }
-        StructureIndex index = StructureIndex.fromClasspath(VERSION_SLOT);
+        StructureIndex index = StructureIndex.fromClasspath(versionSlot);
 
         // Extensions (DESIGN §7.3): baked into the image under EXTENSION_DIR, optionally
         // narrowed by MODULE_CONFIG.activeExtensions. Merges schemas + structure-index in
         // place and yields the discriminators that route augmented structures.
         ExtensionLoader.Result ext = ExtensionLoader.load(
-            Path.of(config.extensionDir()), mc.activeExtensions(), HL7_VERSION, schemas, index);
+            Path.of(config.extensionDir()), mc.activeExtensions(), hl7Version, schemas, index);
 
         StructureResolver resolver = resolverFor(ext.discriminators());
         Map<String, String> extensionScopes = new java.util.LinkedHashMap<>();
@@ -132,10 +135,10 @@ public final class Hl7ApiServer {
         MessageMaterializer materializer = index != null
             ? new Materializer(index, resolver) : new EnvelopeMaterializer();
         LOG.info("Materializer: {}; {} schemas, {} extension(s)", index != null
-            ? "structure-index " + VERSION_SLOT : "ENVELOPE fallback", schemas.size(), ext.loaded().size());
+            ? "structure-index " + versionSlot : "ENVELOPE fallback", schemas.size(), ext.loaded().size());
 
         this.listener = new Hl7ListenerService(config.mllpPort(),
-            new BufferingApp(buffer, materializer, VERSION_SLOT));
+            new BufferingApp(buffer, materializer, versionSlot));
         listener.start();
         LOG.info("MLLP listener up on {}", config.mllpPort());
 
@@ -146,7 +149,7 @@ public final class Hl7ApiServer {
         this.health = new HealthCheck(buffer, listener::isRunning, ext.loaded());
 
         // --- producer surface ---
-        ObjectTree tree = new ObjectTree(buffer, schemas, VERSION_SLOT, extensionScopes);
+        ObjectTree tree = new ObjectTree(buffer, schemas, versionSlot, extensionScopes);
         this.facade = new Hl7ProducerFacade(buffer, tree, schemas);
 
         Javalin app = Javalin.create(cfg -> {

--- a/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/ModuleRuntimeConfig.java
+++ b/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/ModuleRuntimeConfig.java
@@ -16,7 +16,7 @@ import java.util.Set;
  *
  * <pre>
  * { "activeExtensions": ["epic-adt"],
- *   "hl7Version": "2.5.1",
+ *   "hl7Version": "2.7",
  *   "ackDurability": "full",
  *   "retention": { "maxBytes": 10737418240, "maxAge": "P7D" } }
  * </pre>
@@ -31,12 +31,26 @@ import java.util.Set;
 public record ModuleRuntimeConfig(
         Set<String> activeExtensions,
         boolean fullDurability,
-        RetentionConfig retention) {
+        RetentionConfig retention,
+        String hl7Version) {
 
     private static final Gson GSON = new Gson();
+    /** Target HL7 version when MODULE_CONFIG omits it (the version this image bakes). */
+    static final String DEFAULT_HL7_VERSION = "2.7";
 
     private static ModuleRuntimeConfig defaults() {
-        return new ModuleRuntimeConfig(new LinkedHashSet<>(), false, RetentionConfig.none());
+        return new ModuleRuntimeConfig(
+            new LinkedHashSet<>(), false, RetentionConfig.none(), DEFAULT_HL7_VERSION);
+    }
+
+    /**
+     * HAPI structure package / structure-index slot for {@link #hl7Version()} —
+     * {@code "2.7" -> "v27"}, {@code "2.5.1" -> "v251"} (HAPI's
+     * {@code ca.uhn.hl7v2.model.vNN} naming). If the configured version's index
+     * isn't baked into the image, the runtime degrades to the envelope schema.
+     */
+    public String versionSlot() {
+        return "v" + hl7Version.replace(".", "");
     }
 
     public static ModuleRuntimeConfig fromEnv() {
@@ -61,7 +75,10 @@ public record ModuleRuntimeConfig(
             boolean full = obj.has("ackDurability")
                 && obj.get("ackDurability").isJsonPrimitive()
                 && "full".equalsIgnoreCase(obj.get("ackDurability").getAsString());
-            return new ModuleRuntimeConfig(active, full, parseRetention(obj));
+            String version = (obj.has("hl7Version") && obj.get("hl7Version").isJsonPrimitive()
+                && !obj.get("hl7Version").getAsString().isBlank())
+                ? obj.get("hl7Version").getAsString() : DEFAULT_HL7_VERSION;
+            return new ModuleRuntimeConfig(active, full, parseRetention(obj), version);
         } catch (RuntimeException malformed) {
             // Malformed MODULE_CONFIG (bad JSON, wrong-typed/garbage fields) → safe
             // defaults rather than crashing the daemon at boot. The platform transports

--- a/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/ext/ExtensionLoader.java
+++ b/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/ext/ExtensionLoader.java
@@ -53,7 +53,7 @@ public final class ExtensionLoader {
     /**
      * @param extensionDir     in-image {@code EXTENSION_DIR}
      * @param activeExtensions pack names to activate (from {@code MODULE_CONFIG}); empty = all
-     * @param hl7Version       the module's HL7 version (e.g. {@code 2.5.1}) for compat check
+     * @param hl7Version       the module's HL7 version (e.g. {@code 2.7}) for compat check
      */
     public static Result load(Path extensionDir, Set<String> activeExtensions, String hl7Version,
             SchemaRegistry registry, StructureIndex index) {

--- a/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/ext/ExtensionManifest.java
+++ b/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/ext/ExtensionManifest.java
@@ -18,7 +18,7 @@ import java.util.List;
  * <pre>
  * {
  *   "namespace": "epic",
- *   "hl7Version": "2.5.1",
+ *   "hl7Version": "2.7",
  *   "vendor": "epic",
  *   "discriminators": [
  *     { "messageCode": "ADT", "senderEquals": "EPIC", "structure": "ADT_A01_with_ZPV" }

--- a/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/health/HealthSelfTest.java
+++ b/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/health/HealthSelfTest.java
@@ -26,7 +26,7 @@ public final class HealthSelfTest {
 
     /** @return true iff the synthetic message round-tripped with an AA acknowledgment. */
     public static boolean run(int listenerPort) {
-        String er7 = "MSH|^~\\&|HEALTHCHECK|SELF|RECV|DEST|20260101000000||ZZZ^X01|HC-SELFTEST|P|2.5.1\r";
+        String er7 = "MSH|^~\\&|HEALTHCHECK|SELF|RECV|DEST|20260101000000||ZZZ^X01|HC-SELFTEST|P|2.7\r";
         try (HapiContext ctx = new DefaultHapiContext()) {
             ctx.setValidationContext(ValidationContextFactory.noValidation());
             ctx.setModelClassFactory(new GenericModelClassFactory());

--- a/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/producer/Hl7ProducerFacade.java
+++ b/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/producer/Hl7ProducerFacade.java
@@ -59,12 +59,12 @@ public final class Hl7ProducerFacade {
         requireId(objectId);
         List<Map<String, Object>> children = tree.children(objectId);
         int size = clampPageSize(pageSize);
-        int from = Math.max(0, pageNumber) * size;
-        if (from >= children.size()) {
-            return "[]";
-        }
-        int to = Math.min(children.size(), from + size);
-        return GSON.toJson(children.subList(from, to));
+        int from = Math.max(0, pageNumber - 1) * size;
+        int total = children.size();
+        List<Map<String, Object>> page = from >= total
+            ? List.of()
+            : children.subList(from, Math.min(total, from + size));
+        return pagedResults(page, total, size, pageNumber);
     }
 
     // --- Collections (read-only browse) -----------------------------------
@@ -74,7 +74,7 @@ public final class Hl7ProducerFacade {
         requireId(objectId);
         ObjectTree.Collection coll = tree.resolveCollection(objectId);
         int size = clampPageSize(pageSize);
-        int offset = Math.max(0, pageNumber) * size;
+        int offset = Math.max(0, pageNumber - 1) * size;
         String where = composeWhere(coll, filter);
 
         List<BufferRow> rows = buffer.search(where, size, offset);
@@ -82,7 +82,8 @@ public final class Hl7ProducerFacade {
         for (BufferRow r : rows) {
             elements.add(toElement(r));
         }
-        return GSON.toJson(elements);
+        long total = buffer.countWhere(where);
+        return pagedResults(elements, total, size, pageNumber);
     }
 
     public String getCollectionElement(String objectId, String elementKey) throws SQLException {
@@ -181,6 +182,26 @@ public final class Hl7ProducerFacade {
             return a;
         }
         return "(" + a + ") AND (" + b + ")";
+    }
+
+    /**
+     * The DataProducer {@code PagedResults} envelope. Paginated operations
+     * ({@code getChildren}/{@code searchChildObjects},
+     * {@code getCollectionElements}/{@code searchCollectionElements}) MUST return
+     * this shape — the platform's generated producer client deserializes the RPC
+     * body into a paged bag and raises "Producers must return 'items' for
+     * PagedResults queries" when {@code items} is absent. A bare array (the
+     * OpenAPI response schema, but not the runtime contract) breaks the
+     * data-explorer tree. {@code count} is the total matching rows, not the page.
+     */
+    private static String pagedResults(List<Map<String, Object>> items, long count,
+            int pageSize, int pageNumber) {
+        Map<String, Object> envelope = new LinkedHashMap<>();
+        envelope.put("items", items);
+        envelope.put("count", count);
+        envelope.put("pageSize", pageSize);
+        envelope.put("pageNumber", pageNumber);
+        return GSON.toJson(envelope);
     }
 
     private int clampPageSize(int pageSize) {

--- a/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/producer/OperationRouter.java
+++ b/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/producer/OperationRouter.java
@@ -56,7 +56,7 @@ public final class OperationRouter {
                 return facade.getChildren(
                     str(argMap, "objectId"),
                     getInt(argMap, "pageSize", 100),
-                    getInt(argMap, "pageNumber", 1) - 1);
+                    getInt(argMap, "pageNumber", 1));
             case "createChildObject":
             case "updateObject":
             case "deleteObject":
@@ -78,7 +78,7 @@ public final class OperationRouter {
                     str(argMap, "sortBy"),
                     str(argMap, "sortDir"),
                     getInt(argMap, "pageSize", 100),
-                    getInt(argMap, "pageNumber", 1) - 1,
+                    getInt(argMap, "pageNumber", 1),
                     str(argMap, "pageToken"));
             case "getCollectionElement":
                 return facade.getCollectionElement(

--- a/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/producer/SchemaRegistry.java
+++ b/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/producer/SchemaRegistry.java
@@ -192,7 +192,7 @@ public final class SchemaRegistry {
 
     /**
      * All message-structure names → their collection schema id, across every
-     * namespace (base {@code v251} + extension namespaces like {@code epic}). Drives
+     * namespace (base {@code v27} + extension namespaces like {@code epic}). Drives
      * the namespace-agnostic {@code /by-type/<X>} listing once extensions are merged.
      * Insertion order: base then extensions.
      */

--- a/package/hl7/v2/java/src/main/resources/README.md
+++ b/package/hl7/v2/java/src/main/resources/README.md
@@ -15,13 +15,13 @@ Layout produced under this directory:
 
 ```
 schemas/
-  v251/
-    messages/   ADT_A01.json, ORU_R01.json, ...   schema:table:hl7v2.v251.<MSG>
-    segments/   MSH.json, PID.json, ...            schema:type:hl7v2.v251.<SEG>
-    datatypes/  CX.json, XPN.json, HD.json, ...    schema:type:hl7v2.v251.<DT>
-    tables/     HL70001.json, ...                  schema:enum:hl7v2.v251.<HL7nnnn>
+  v27/
+    messages/   ADT_A01.json, ORU_R01.json, ...   schema:table:hl7v2.v27.<MSG>
+    segments/   MSH.json, PID.json, ...            schema:type:hl7v2.v27.<SEG>
+    datatypes/  CX.json, XPN.json, HD.json, ...    schema:type:hl7v2.v27.<DT>
+    tables/     HL70001.json, ...                  schema:enum:hl7v2.v27.<HL7nnnn>
 structure-index/
-  v251.json     runtime materializer driver
+  v27.json      runtime materializer driver
 ```
 
 Regenerate with:
@@ -29,7 +29,7 @@ Regenerate with:
 ```
 mvn -f java/codegen/pom.xml compile exec:java \
   -Dexec.mainClass=com.zerobias.module.hl7.codegen.SchemaGenerator \
-  -Dexec.args="v251 java/src/main/resources"
+  -Dexec.args="v27 java/src/main/resources"
 ```
 
 (or `mvn -Pregen-schemas generate-resources` from `java/`).

--- a/package/hl7/v2/java/src/test/java/com/zerobias/module/hl7/ModuleRuntimeConfigTest.java
+++ b/package/hl7/v2/java/src/test/java/com/zerobias/module/hl7/ModuleRuntimeConfigTest.java
@@ -90,4 +90,25 @@ class ModuleRuntimeConfigTest {
         assertEquals(Set.of(), ModuleRuntimeConfig.parse("not json at all").activeExtensions());
         assertEquals(Set.of(), ModuleRuntimeConfig.parse("{\"activeExtensions\":[").activeExtensions());
     }
+
+    @Test
+    void hl7VersionDefaultsTo27AndDrivesTheSlot() {
+        // absent / empty / malformed → the baked-in default (2.7 -> v27)
+        assertEquals("2.7", ModuleRuntimeConfig.parse("{}").hl7Version());
+        assertEquals("v27", ModuleRuntimeConfig.parse("{}").versionSlot());
+        assertEquals("2.7", ModuleRuntimeConfig.parse(null).hl7Version());
+        assertEquals("v27", ModuleRuntimeConfig.parse("not json at all").versionSlot());
+        // blank string is ignored → default
+        assertEquals("2.7", ModuleRuntimeConfig.parse("{\"hl7Version\":\"\"}").hl7Version());
+    }
+
+    @Test
+    void hl7VersionParsesAndNormalizesToHapiSlot() {
+        assertEquals("v27", ModuleRuntimeConfig.parse("{\"hl7Version\":\"2.7\"}").versionSlot());
+        // an operator targeting a different baked version: 2.5.1 -> v251 (slot only;
+        // whether that index ships is a build concern — runtime falls back if absent)
+        var c = ModuleRuntimeConfig.parse("{\"hl7Version\":\"2.5.1\"}");
+        assertEquals("2.5.1", c.hl7Version());
+        assertEquals("v251", c.versionSlot());
+    }
 }

--- a/package/hl7/v2/java/src/test/java/com/zerobias/module/hl7/buffer/BufferStoreTest.java
+++ b/package/hl7/v2/java/src/test/java/com/zerobias/module/hl7/buffer/BufferStoreTest.java
@@ -25,8 +25,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class BufferStoreTest {
 
     private static final Instant BASE = Instant.parse("2026-05-29T00:00:00Z");
-    private static final String SCHEMA_A = "schema:table:hl7v2.v251.ADT_A01";
-    private static final String SCHEMA_B = "schema:table:hl7v2.v251.ORU_R01";
+    private static final String SCHEMA_A = "schema:table:hl7v2.v27.ADT_A01";
+    private static final String SCHEMA_B = "schema:table:hl7v2.v27.ORU_R01";
 
     private BufferStore open(Path dir, MutableClock clock) throws Exception {
         return new BufferStore(dir.resolve("buffer.db").toString(), false, clock);
@@ -34,7 +34,7 @@ class BufferStoreTest {
 
     private static BufferRow row(String controlId, long offsetSec, String schemaId) {
         return new BufferRow(0, BASE.plusSeconds(offsetSec), controlId, "ADT_A01", "ADT", "A01",
-            "EPIC", "HOSP", "2.5.1", schemaId, ("raw-" + controlId).getBytes(),
+            "EPIC", "HOSP", "2.7", schemaId, ("raw-" + controlId).getBytes(),
             "{\"controlId\":\"" + controlId + "\"}", MessageStatus.NEW, null, null, null);
     }
 

--- a/package/hl7/v2/java/src/test/java/com/zerobias/module/hl7/ext/ExtensionLoaderIT.java
+++ b/package/hl7/v2/java/src/test/java/com/zerobias/module/hl7/ext/ExtensionLoaderIT.java
@@ -57,7 +57,7 @@ class ExtensionLoaderIT {
         Files.writeString(ext.resolve("segments/ZPV.json"),
             "{\"id\":\"schema:type:hl7v2.epic.ZPV\",\"dataTypes\":[],\"properties\":[]}");
         Files.writeString(ext.resolve("structure-index.json"),
-            "{\"version\":\"v251\",\"messages\":{\"ADT_A01_with_ZPV\":{\"structures\":["
+            "{\"version\":\"v27\",\"messages\":{\"ADT_A01_with_ZPV\":{\"structures\":["
             + "{\"name\":\"msh\",\"structure\":\"MSH\",\"group\":false,\"required\":true,\"multi\":false},"
             + "{\"name\":\"pid\",\"structure\":\"PID\",\"group\":false,\"required\":true,\"multi\":false},"
             + "{\"name\":\"zpv\",\"structure\":\"ZPV\",\"group\":false,\"required\":false,\"multi\":false}"
@@ -86,14 +86,14 @@ class ExtensionLoaderIT {
 
     @Test
     void loadMergesSurfacesByTypeAndRoutes(@TempDir Path extRoot, @TempDir Path dbDir) throws Exception {
-        stageEpicPack(extRoot, "epic-adt", "2.5.1");
+        stageEpicPack(extRoot, "epic-adt", "2.7");
 
         SchemaRegistry registry = SchemaRegistry.fromClasspath();
-        StructureIndex index = StructureIndex.fromClasspath("v251");
+        StructureIndex index = StructureIndex.fromClasspath("v27");
         int baseSize = registry.size();
 
         ExtensionLoader.Result result = ExtensionLoader.load(
-            extRoot, Set.of(), "2.5.1", registry, index);
+            extRoot, Set.of(), "2.7", registry, index);
 
         // merged: new schemas served, health descriptor reported
         assertTrue(registry.size() > baseSize, "extension schemas merged");
@@ -108,7 +108,7 @@ class ExtensionLoaderIT {
             scopes.put(d.structure(), d.whereClause());
         }
         try (BufferStore buffer = new BufferStore(dbDir.resolve("buffer.db").toString(), false)) {
-            ObjectTree tree = new ObjectTree(buffer, registry, "v251", scopes);
+            ObjectTree tree = new ObjectTree(buffer, registry, "v27", scopes);
             List<String> byType = tree.children("/hl7-v2-receiver/by-type").stream()
                 .map(o -> o.get("id").toString()).toList();
             assertTrue(byType.contains("/hl7-v2-receiver/by-type/ADT_A01_with_ZPV"),
@@ -126,7 +126,7 @@ class ExtensionLoaderIT {
         // routing: an EPIC ADT with a ZPV segment materializes the ZPV (via the discriminator)
         Materializer m = new Materializer(index, resolverFor(result.discriminators()));
         String er7 = String.join(CR,
-            "MSH|^~\\&|EPIC|HOSP|RECV|DEST|20260101000000||ADT^A01^ADT_A01|MSGX|P|2.5.1",
+            "MSH|^~\\&|EPIC|HOSP|RECV|DEST|20260101000000||ADT^A01^ADT_A01|MSGX|P|2.7",
             "PID|1||5551212^^^EPIC^MR||SMITH^JOHN||19800101|M",
             "ZPV|VISIT-789") + CR;
         JsonObject root = GSON.fromJson(m.toTypedJson(parseGeneric(er7)), JsonObject.class);
@@ -136,38 +136,38 @@ class ExtensionLoaderIT {
 
     @Test
     void activeExtensionsFilterExcludes(@TempDir Path extRoot) throws Exception {
-        stageEpicPack(extRoot, "epic-adt", "2.5.1");
+        stageEpicPack(extRoot, "epic-adt", "2.7");
         SchemaRegistry registry = SchemaRegistry.fromClasspath();
-        StructureIndex index = StructureIndex.fromClasspath("v251");
+        StructureIndex index = StructureIndex.fromClasspath("v27");
 
         // only "other" is active → epic-adt is skipped
         ExtensionLoader.Result result = ExtensionLoader.load(
-            extRoot, Set.of("other"), "2.5.1", registry, index);
+            extRoot, Set.of("other"), "2.7", registry, index);
         assertTrue(result.loaded().isEmpty());
         assertFalse(registry.has("schema:table:hl7v2.epic.ADT_A01_with_ZPV"));
     }
 
     @Test
     void duplicateSchemaIdAcrossPacksRejected(@TempDir Path extRoot) throws Exception {
-        stageEpicPack(extRoot, "epic-adt", "2.5.1");
-        stageEpicPack(extRoot, "epic-dup", "2.5.1");   // same epic schema ids
+        stageEpicPack(extRoot, "epic-adt", "2.7");
+        stageEpicPack(extRoot, "epic-dup", "2.7");   // same epic schema ids
         SchemaRegistry registry = SchemaRegistry.fromClasspath();
-        StructureIndex index = StructureIndex.fromClasspath("v251");
+        StructureIndex index = StructureIndex.fromClasspath("v27");
 
         IllegalStateException e = assertThrows(IllegalStateException.class,
-            () -> ExtensionLoader.load(extRoot, Set.of(), "2.5.1", registry, index));
+            () -> ExtensionLoader.load(extRoot, Set.of(), "2.7", registry, index));
         // distinguish from the version-mismatch rejection: this is the dup-id path
         assertTrue(e.getMessage().contains("duplicate schema id"), e.getMessage());
     }
 
     @Test
     void versionMismatchRejected(@TempDir Path extRoot) throws Exception {
-        stageEpicPack(extRoot, "epic-adt", "2.3");      // module is 2.5.1
+        stageEpicPack(extRoot, "epic-adt", "2.3");      // module is 2.7
         SchemaRegistry registry = SchemaRegistry.fromClasspath();
-        StructureIndex index = StructureIndex.fromClasspath("v251");
+        StructureIndex index = StructureIndex.fromClasspath("v27");
 
         IllegalStateException e = assertThrows(IllegalStateException.class,
-            () -> ExtensionLoader.load(extRoot, Set.of(), "2.5.1", registry, index));
+            () -> ExtensionLoader.load(extRoot, Set.of(), "2.7", registry, index));
         // distinguish from the dup-id rejection: this is the version-compat path
         assertTrue(e.getMessage().contains("targets HL7"), e.getMessage());
     }

--- a/package/hl7/v2/java/src/test/java/com/zerobias/module/hl7/filter/Hl7SqlAdapterIT.java
+++ b/package/hl7/v2/java/src/test/java/com/zerobias/module/hl7/filter/Hl7SqlAdapterIT.java
@@ -88,8 +88,8 @@ class Hl7SqlAdapterIT {
             Map<String, Object> obj = m.asObject();
             String json = GSON.toJson(obj);
             BufferRow row = new BufferRow(0, Instant.parse(m.receivedAt()), m.controlId(),
-                "ADT_A01", "ADT", "A01", "EPIC", "HOSP", "2.5.1",
-                "schema:table:hl7v2.v251.ADT_A01", ("raw-" + m.controlId()).getBytes(),
+                "ADT_A01", "ADT", "A01", "EPIC", "HOSP", "2.7",
+                "schema:table:hl7v2.v27.ADT_A01", ("raw-" + m.controlId()).getBytes(),
                 json, MessageStatus.fromWire(m.status()), null, null, null);
             assertTrue(store.insert(row), "insert " + m.controlId());
         }

--- a/package/hl7/v2/java/src/test/java/com/zerobias/module/hl7/health/HealthCheckTest.java
+++ b/package/hl7/v2/java/src/test/java/com/zerobias/module/hl7/health/HealthCheckTest.java
@@ -26,7 +26,7 @@ class HealthCheckTest {
 
     private static void insert(BufferStore b, String cid, long offsetSec) throws Exception {
         b.insert(new BufferRow(0, Instant.parse("2026-05-28T00:00:00Z").plusSeconds(offsetSec), cid,
-            "ADT_A01", "ADT", "A01", "EPIC", "HOSP", "2.5.1", "schema:table:hl7v2.v251.ADT_A01",
+            "ADT_A01", "ADT", "A01", "EPIC", "HOSP", "2.7", "schema:table:hl7v2.v27.ADT_A01",
             ("raw-" + cid).getBytes(), "{}", MessageStatus.NEW, null, null, null));
     }
 

--- a/package/hl7/v2/java/src/test/java/com/zerobias/module/hl7/health/HealthSelfTestIT.java
+++ b/package/hl7/v2/java/src/test/java/com/zerobias/module/hl7/health/HealthSelfTestIT.java
@@ -40,7 +40,7 @@ class HealthSelfTestIT {
         int port = freePort();
         try (BufferStore buffer = new BufferStore(dir.resolve("buffer.db").toString(), false);
              Hl7ListenerService listener = new Hl7ListenerService(port,
-                 new BufferingApp(buffer, new EnvelopeMaterializer(), "v251"))) {
+                 new BufferingApp(buffer, new EnvelopeMaterializer(), "v27"))) {
             listener.start();
 
             assertTrue(HealthSelfTest.run(port), "self-test should round-trip AA");
@@ -53,7 +53,7 @@ class HealthSelfTestIT {
             try (HapiContext ctx = new DefaultHapiContext()) {
                 ctx.setValidationContext(ValidationContextFactory.noValidation());
                 ctx.setModelClassFactory(new GenericModelClassFactory());
-                String adt = "MSH|^~\\&|EPIC|HOSP|RECV|DEST|20260601120000||ADT^A01^ADT_A01|POST-SELFTEST|P|2.5.1\r"
+                String adt = "MSH|^~\\&|EPIC|HOSP|RECV|DEST|20260601120000||ADT^A01^ADT_A01|POST-SELFTEST|P|2.7\r"
                     + "PID|1||5551212^^^EPIC^MR||DOE^JANE||19850315|F\r";
                 Connection c = ctx.newClient("127.0.0.1", port, false);
                 Message ack = c.getInitiator().sendAndReceive(ctx.getPipeParser().parse(adt));

--- a/package/hl7/v2/java/src/test/java/com/zerobias/module/hl7/listener/BufferingAppTest.java
+++ b/package/hl7/v2/java/src/test/java/com/zerobias/module/hl7/listener/BufferingAppTest.java
@@ -25,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class BufferingAppTest {
 
     private static final String ADT =
-        "MSH|^~\\&|EPIC|HOSP|RECV|DEST|20260601120000||ADT^A01^ADT_A01|MSG1|P|2.5.1\r"
+        "MSH|^~\\&|EPIC|HOSP|RECV|DEST|20260601120000||ADT^A01^ADT_A01|MSG1|P|2.7\r"
         + "PID|1||5551212^^^EPIC^MR||DOE^JANE||19850315|F\r";
 
     private Message parse(String er7) throws Exception {
@@ -50,7 +50,7 @@ class BufferingAppTest {
             MessageMaterializer boom = msg -> {
                 throw new RuntimeException("materialize failed");
             };
-            BufferingApp app = new BufferingApp(buffer, boom, "v251");
+            BufferingApp app = new BufferingApp(buffer, boom, "v27");
 
             Message ack = app.processMessage(parse(ADT), new java.util.HashMap<>());
 
@@ -62,7 +62,7 @@ class BufferingAppTest {
     @Test
     void successPersistsAndAcksAa(@TempDir Path dir) throws Exception {
         try (BufferStore buffer = new BufferStore(dir.resolve("buffer.db").toString(), false)) {
-            BufferingApp app = new BufferingApp(buffer, new EnvelopeMaterializer(), "v251");
+            BufferingApp app = new BufferingApp(buffer, new EnvelopeMaterializer(), "v27");
             Message ack = app.processMessage(parse(ADT), new java.util.HashMap<>());
             assertEquals("AA", new Terser(ack).get("/MSA-1"));
             assertEquals(1, buffer.count());

--- a/package/hl7/v2/java/src/test/java/com/zerobias/module/hl7/listener/Hl7ListenerIT.java
+++ b/package/hl7/v2/java/src/test/java/com/zerobias/module/hl7/listener/Hl7ListenerIT.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class Hl7ListenerIT {
 
     private static final String ER7 = String.join("\r",
-        "MSH|^~\\&|EPIC|HOSP|RECV|DEST|20260529103000||ADT^A01^ADT_A01|MSG00001|P|2.5.1",
+        "MSH|^~\\&|EPIC|HOSP|RECV|DEST|20260529103000||ADT^A01^ADT_A01|MSG00001|P|2.7",
         "EVN|A01|20260529103000",
         "PID|1||5551212^^^EPIC^MR||SMITH^JOHN||19800101|M",
         "PV1|1|I") + "\r";
@@ -40,7 +40,7 @@ class Hl7ListenerIT {
         final int port = freePort();
         try (BufferStore buffer = new BufferStore(dir.resolve("buffer.db").toString(), false);
              Hl7ListenerService listener = new Hl7ListenerService(
-                 port, new BufferingApp(buffer, new EnvelopeMaterializer(), "v251"));
+                 port, new BufferingApp(buffer, new EnvelopeMaterializer(), "v27"));
              HapiContext client = new DefaultHapiContext()) {
 
             listener.start();
@@ -60,7 +60,7 @@ class Hl7ListenerIT {
             assertEquals("ADT", row.messageCode());
             assertEquals("A01", row.triggerEvent());
             assertEquals("EPIC", row.sendingApp());
-            assertEquals("schema:table:hl7v2.v251.ADT_A01", row.schemaId());
+            assertEquals("schema:table:hl7v2.v27.ADT_A01", row.schemaId());
             assertNotNull(row.rawEr7());
             assertTrue(row.mappedJson().contains("\"patientFamilyName\":\"SMITH\""),
                 "materialized JSON: " + row.mappedJson());

--- a/package/hl7/v2/java/src/test/java/com/zerobias/module/hl7/materializer/MaterializerIT.java
+++ b/package/hl7/v2/java/src/test/java/com/zerobias/module/hl7/materializer/MaterializerIT.java
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 /**
  * Phase 3 validation (DESIGN §5): the full structure-index-driven materializer,
  * run against the <em>real</em> generated index (produced by the codegen into
- * {@code $HL7_INDEX_DIR/structure-index/v251.json} by manual-test.sh, exactly as
+ * {@code $HL7_INDEX_DIR/structure-index/v27.json} by manual-test.sh, exactly as
  * the build would) and a generically-parsed message.
  *
  * <p>Parsing is forced generic via {@link GenericModelClassFactory} to mirror
@@ -36,12 +36,12 @@ class MaterializerIT {
     private Materializer materializer() {
         // Prefer the classpath index the real build generates into target/classes
         // (so this runs in CI); fall back to HL7_INDEX_DIR for the manual harness.
-        StructureIndex index = StructureIndex.fromClasspath("v251");
+        StructureIndex index = StructureIndex.fromClasspath("v27");
         if (index == null) {
             String dir = System.getenv("HL7_INDEX_DIR");
             assumeTrue(dir != null && !dir.isBlank(),
                 "no classpath structure-index and HL7_INDEX_DIR unset; skipping");
-            index = StructureIndex.fromFile(Path.of(dir, "structure-index", "v251.json"));
+            index = StructureIndex.fromFile(Path.of(dir, "structure-index", "v27.json"));
         }
         return new Materializer(index);
     }
@@ -59,7 +59,7 @@ class MaterializerIT {
         Materializer m = materializer();
         // The DESIGN §5 PID, with MSH framing. PID-3 CX: idNumber^^^assigningAuthority(HD)^typeCode.
         String er7 = String.join(CR,
-            "MSH|^~\\&|EPIC|HOSP|RECV|DEST|20260529103000||ADT^A01^ADT_A01|MSG1|P|2.5.1",
+            "MSH|^~\\&|EPIC|HOSP|RECV|DEST|20260529103000||ADT^A01^ADT_A01|MSG1|P|2.7",
             "EVN|A01|20260529103000",
             "PID|1||5551212^^^EPIC&&ISO^MR||SMITH^JOHN||19800101|M",
             "PV1|1|I") + CR;
@@ -89,14 +89,15 @@ class MaterializerIT {
         assertEquals("SMITH", xpn.getAsJsonObject("familyName").get("surname").getAsString());
         assertEquals("JOHN", xpn.get("givenName").getAsString());
 
-        // PID-7 dateTimeOfBirth: TS is a composite in v2.5.1 (TS-1 = time), so the
-        // value nests under "time" — faithful to the schema. The date is
-        // precision-preserving (NO fabricated midnight — the validated normalizer's
-        // contract; DESIGN §5's flat "…T00:00:00Z" is illustrative, predates it).
-        assertEquals("1980-01-01", pid.getAsJsonObject("dateTimeOfBirth").get("time").getAsString());
+        // PID-7 dateTimeOfBirth: DTM is a PRIMITIVE in v2.7 (v2.5.1's TS composite
+        // was retired), so the value is a flat string, not nested under "time". The
+        // date is precision-preserving (NO fabricated midnight — the validated
+        // normalizer's contract).
+        assertEquals("1980-01-01", pid.get("dateTimeOfBirth").getAsString());
 
-        // PID-8 administrativeSex: table-bound value emitted as the raw code (tagged, not resolved)
-        assertEquals("M", pid.get("administrativeSex").getAsString());
+        // PID-8 administrativeSex: CWE in v2.7 (was IS in v2.5.1), so the bare code
+        // "M" lands in CWE-1 identifier — emitted as the raw code (tagged, not resolved)
+        assertEquals("M", pid.getAsJsonObject("administrativeSex").get("identifier").getAsString());
 
         // MSH-3 sendingApplication is an HD composite
         assertEquals("EPIC",
@@ -107,7 +108,7 @@ class MaterializerIT {
     void oruRoundTripsWithRepeatingObx() throws Exception {
         Materializer m = materializer();
         String er7 = String.join(CR,
-            "MSH|^~\\&|LAB|HOSP|RECV|DEST|20260529103000||ORU^R01^ORU_R01|MSG2|P|2.5.1",
+            "MSH|^~\\&|LAB|HOSP|RECV|DEST|20260529103000||ORU^R01^ORU_R01|MSG2|P|2.7",
             "PID|1||9001234^^^LAB^MR||DOE^JANE||19750210|F",
             "OBR|1|||CBC^Complete Blood Count",
             "OBX|1|NM|WBC^White Blood Count||7.2|10*3/uL|||||F",
@@ -132,20 +133,21 @@ class MaterializerIT {
         Materializer m = materializer();
         // The HL7 explicit-null sentinel ("") must survive as JSON null with the key
         // PRESENT (serializeNulls), distinct from an absent field whose key is omitted.
-        // Exercised on a PRIMITIVE field (PID-8 administrativeSex, IS): a composite
-        // field's "" would surface the null nested under its first component, not at the
-        // field's top level, so a primitive is the faithful explicit-null probe.
-        // PID-7 (dateTimeOfBirth) is left empty → absent.
+        // Exercised on a PRIMITIVE field (PID-1 setIDPID, SI): a composite field's ""
+        // would surface the null nested under its first component, not at the field's
+        // top level, so a primitive is the faithful explicit-null probe. (In v2.7
+        // PID-8 administrativeSex is a CWE composite, so it is no longer usable here.)
+        // PID-7 (dateTimeOfBirth) is left absent → key omitted.
         String er7 = String.join(CR,
-            "MSH|^~\\&|EPIC|HOSP|RECV|DEST|20260529103000||ADT^A01^ADT_A01|MSG3|P|2.5.1",
-            "PID|1||5551212^^^EPIC^MR||SMITH^JOHN|||\"\"") + CR;
+            "MSH|^~\\&|EPIC|HOSP|RECV|DEST|20260529103000||ADT^A01^ADT_A01|MSG3|P|2.7",
+            "PID|\"\"||5551212^^^EPIC^MR||SMITH^JOHN") + CR;
 
         JsonObject pid = GSON.fromJson(m.toTypedJson(parseGeneric(er7)), JsonObject.class)
             .getAsJsonObject("pid");
-        // dateTimeOfBirth (PID-7) was empty → key omitted entirely
+        // dateTimeOfBirth (PID-7) was absent → key omitted entirely
         assertTrue(!pid.has("dateTimeOfBirth"), "absent field omitted");
-        // administrativeSex (PID-8) was "" → key present, value JSON null
-        assertTrue(pid.has("administrativeSex"), "explicit-null field key is present");
-        assertTrue(pid.get("administrativeSex").isJsonNull(), "HL7 \"\" → JSON null");
+        // setIDPID (PID-1) was "" → key present, value JSON null
+        assertTrue(pid.has("setIDPID"), "explicit-null field key is present");
+        assertTrue(pid.get("setIDPID").isJsonNull(), "HL7 \"\" → JSON null");
     }
 }

--- a/package/hl7/v2/java/src/test/java/com/zerobias/module/hl7/producer/Hl7OperationsIT.java
+++ b/package/hl7/v2/java/src/test/java/com/zerobias/module/hl7/producer/Hl7OperationsIT.java
@@ -37,14 +37,14 @@ class Hl7OperationsIT {
     private BufferStore buffer;
 
     private Hl7ProducerFacade facade(Path dir) throws Exception {
-        writeSchema(dir, "schemas/v251/messages/ADT_A01.json", "schema:table:hl7v2.v251.ADT_A01");
-        writeSchema(dir, "schemas/v251/messages/ORU_R01.json", "schema:table:hl7v2.v251.ORU_R01");
+        writeSchema(dir, "schemas/v27/messages/ADT_A01.json", "schema:table:hl7v2.v27.ADT_A01");
+        writeSchema(dir, "schemas/v27/messages/ORU_R01.json", "schema:table:hl7v2.v27.ORU_R01");
         buffer = new BufferStore(dir.resolve("buffer.db").toString(), false);
         insert("M1", "ADT_A01", "ADT");
         insert("M2", "ADT_A01", "ADT");
         insert("M3", "ORU_R01", "ORU");
         SchemaRegistry schemas = SchemaRegistry.fromDirectory(dir);
-        return new Hl7ProducerFacade(buffer, new ObjectTree(buffer, schemas, "v251"), schemas);
+        return new Hl7ProducerFacade(buffer, new ObjectTree(buffer, schemas, "v27"), schemas);
     }
 
     private static void writeSchema(Path dir, String rel, String id) throws Exception {
@@ -55,7 +55,7 @@ class Hl7OperationsIT {
 
     private void insert(String cid, String struct, String code) throws Exception {
         buffer.insert(new BufferRow(0, Instant.parse("2026-05-28T10:00:00Z"), cid, struct, code, "A01",
-            "EPIC", "HOSP", "2.5.1", "schema:table:hl7v2.v251." + struct, ("raw-" + cid).getBytes(),
+            "EPIC", "HOSP", "2.7", "schema:table:hl7v2.v27." + struct, ("raw-" + cid).getBytes(),
             "{\"msh\":{\"messageType\":{\"messageCode\":\"" + code + "\"}}}",
             MessageStatus.NEW, null, null, null));
     }

--- a/package/hl7/v2/java/src/test/java/com/zerobias/module/hl7/producer/Hl7ProducerIT.java
+++ b/package/hl7/v2/java/src/test/java/com/zerobias/module/hl7/producer/Hl7ProducerIT.java
@@ -71,6 +71,21 @@ class Hl7ProducerIT {
         return OperationRouter.executeOperation(f, method, args);
     }
 
+    /**
+     * Unwrap a paginated op's response, asserting the {@code PagedResults}
+     * envelope the platform requires ({@code items}/{@code count}/{@code pageSize}/
+     * {@code pageNumber}) — a bare array trips "Producers must return 'items' for
+     * PagedResults queries" and breaks the data-explorer tree.
+     */
+    private static JsonArray pagedItems(String json) {
+        JsonObject env = GSON.fromJson(json, JsonObject.class);
+        assertTrue(env.has("items"), "PagedResults must have 'items': " + json);
+        assertTrue(env.has("count"), "PagedResults must have 'count': " + json);
+        assertTrue(env.has("pageSize"), "PagedResults must have 'pageSize': " + json);
+        assertTrue(env.has("pageNumber"), "PagedResults must have 'pageNumber': " + json);
+        return env.getAsJsonArray("items");
+    }
+
     @Test
     void rootAndContainers(@TempDir Path dir) throws Exception {
         Hl7ProducerFacade f = facade(dir);
@@ -84,14 +99,14 @@ class Hl7ProducerIT {
         assertTrue(classes(receiver).contains("container"));
 
         // root has exactly one child: the receiver
-        JsonArray rootChildren = GSON.fromJson(
-            op(f, "ObjectsApi.getChildren", "objectId", "/"), JsonArray.class);
+        JsonArray rootChildren = pagedItems(
+            op(f, "ObjectsApi.getChildren", "objectId", "/"));
         assertEquals(1, rootChildren.size());
         assertEquals("/hl7-v2-receiver", rootChildren.get(0).getAsJsonObject().get("id").getAsString());
 
         // receiver has exactly: messages, by-type, by-sender, stats, ops
-        JsonArray kids = GSON.fromJson(
-            op(f, "ObjectsApi.getChildren", "objectId", "/hl7-v2-receiver"), JsonArray.class);
+        JsonArray kids = pagedItems(
+            op(f, "ObjectsApi.getChildren", "objectId", "/hl7-v2-receiver"));
         java.util.Set<String> kidIds = kids.asList().stream()
             .map(e -> e.getAsJsonObject().get("id").getAsString())
             .collect(java.util.stream.Collectors.toSet());
@@ -101,6 +116,37 @@ class Hl7ProducerIT {
             "/hl7-v2-receiver/by-sender",
             "/hl7-v2-receiver/stats",
             "/hl7-v2-receiver/ops"), kidIds);
+    }
+
+    @Test
+    void pagedResultsEnvelopeAndPaging(@TempDir Path dir) throws Exception {
+        Hl7ProducerFacade f = facade(dir);
+
+        // getChildren: the envelope's scalar fields are faithful (count = total
+        // children, pageNumber echoes the 1-based request) — a bare array here was
+        // the data-explorer "must return 'items'" blocker.
+        JsonObject env = GSON.fromJson(
+            op(f, "ObjectsApi.getChildren", "objectId", "/hl7-v2-receiver",
+                "pageSize", 2, "pageNumber", 1), JsonObject.class);
+        assertEquals(5, env.get("count").getAsInt());           // 5 children total
+        assertEquals(2, env.get("pageSize").getAsInt());
+        assertEquals(1, env.get("pageNumber").getAsInt());      // 1-based, echoed
+        assertEquals(2, env.getAsJsonArray("items").size());    // first page: 2 of 5
+
+        // page 3 (1-based) of size 2 -> the trailing 1 child, count unchanged
+        JsonObject p3 = GSON.fromJson(
+            op(f, "ObjectsApi.getChildren", "objectId", "/hl7-v2-receiver",
+                "pageSize", 2, "pageNumber", 3), JsonObject.class);
+        assertEquals(5, p3.get("count").getAsInt());
+        assertEquals(1, p3.getAsJsonArray("items").size());
+
+        // collection elements are paged the same way — total count, not page size
+        JsonObject coll = GSON.fromJson(
+            op(f, "CollectionsApi.searchCollectionElements",
+                "objectId", "/hl7-v2-receiver/messages", "pageSize", 2, "pageNumber", 1),
+            JsonObject.class);
+        assertEquals(3, coll.get("count").getAsInt());          // 3 seeded messages
+        assertEquals(2, coll.getAsJsonArray("items").size());   // page caps at 2
     }
 
     @Test
@@ -116,8 +162,8 @@ class Hl7ProducerIT {
     @Test
     void byTypeChildrenFromSchemaRegistry(@TempDir Path dir) throws Exception {
         Hl7ProducerFacade f = facade(dir);
-        JsonArray types = GSON.fromJson(
-            op(f, "ObjectsApi.getChildren", "objectId", "/hl7-v2-receiver/by-type"), JsonArray.class);
+        JsonArray types = pagedItems(
+            op(f, "ObjectsApi.getChildren", "objectId", "/hl7-v2-receiver/by-type"));
         List<String> ids = types.asList().stream()
             .map(e -> e.getAsJsonObject().get("id").getAsString()).toList();
         assertEquals(List.of("/hl7-v2-receiver/by-type/ADT_A01", "/hl7-v2-receiver/by-type/ORU_R01"), ids);
@@ -126,8 +172,8 @@ class Hl7ProducerIT {
     @Test
     void bySenderChildrenFromBuffer(@TempDir Path dir) throws Exception {
         Hl7ProducerFacade f = facade(dir);
-        JsonArray senders = GSON.fromJson(
-            op(f, "ObjectsApi.getChildren", "objectId", "/hl7-v2-receiver/by-sender"), JsonArray.class);
+        JsonArray senders = pagedItems(
+            op(f, "ObjectsApi.getChildren", "objectId", "/hl7-v2-receiver/by-sender"));
         List<String> ids = senders.asList().stream()
             .map(e -> e.getAsJsonObject().get("id").getAsString()).toList();
         assertEquals(List.of("/hl7-v2-receiver/by-sender/CERNER", "/hl7-v2-receiver/by-sender/EPIC"), ids);
@@ -138,29 +184,27 @@ class Hl7ProducerIT {
         Hl7ProducerFacade f = facade(dir);
 
         // all messages
-        JsonArray all = GSON.fromJson(
-            op(f, "CollectionsApi.searchCollectionElements", "objectId", "/hl7-v2-receiver/messages"),
-            JsonArray.class);
+        JsonArray all = pagedItems(
+            op(f, "CollectionsApi.searchCollectionElements", "objectId", "/hl7-v2-receiver/messages"));
         assertEquals(3, all.size());
 
         // scoped to ADT_A01 -> M1, M2
-        JsonArray adt = GSON.fromJson(
+        JsonArray adt = pagedItems(
             op(f, "CollectionsApi.searchCollectionElements",
-                "objectId", "/hl7-v2-receiver/by-type/ADT_A01"), JsonArray.class);
+                "objectId", "/hl7-v2-receiver/by-type/ADT_A01"));
         assertEquals(2, adt.size());
 
         // scope + RFC4515 filter (status column) -> only the un-acked ADT
-        JsonArray adtNew = GSON.fromJson(
+        JsonArray adtNew = pagedItems(
             op(f, "CollectionsApi.searchCollectionElements",
-                "objectId", "/hl7-v2-receiver/by-type/ADT_A01", "filter", "(status=new)"), JsonArray.class);
+                "objectId", "/hl7-v2-receiver/by-type/ADT_A01", "filter", "(status=new)"));
         assertEquals(1, adtNew.size());
         assertEquals("M1", adtNew.get(0).getAsJsonObject().get("controlId").getAsString());
 
         // json-path filter into the typed body
-        JsonArray booth = GSON.fromJson(
+        JsonArray booth = pagedItems(
             op(f, "CollectionsApi.searchCollectionElements",
-                "objectId", "/hl7-v2-receiver/messages", "filter", "(pid.patientFamilyName=BOOTH)"),
-            JsonArray.class);
+                "objectId", "/hl7-v2-receiver/messages", "filter", "(pid.patientFamilyName=BOOTH)"));
         assertEquals(1, booth.size());
         assertEquals("M3", booth.get(0).getAsJsonObject().get("controlId").getAsString());
     }

--- a/package/hl7/v2/java/src/test/java/com/zerobias/module/hl7/producer/Hl7ProducerIT.java
+++ b/package/hl7/v2/java/src/test/java/com/zerobias/module/hl7/producer/Hl7ProducerIT.java
@@ -35,9 +35,9 @@ class Hl7ProducerIT {
     private Hl7ProducerFacade facade(Path dir) throws Exception {
         // --- a minimal generated schema tree (Phase 1 emits the full one) ---
         writeSchema(dir, "schemas/shared/message-envelope.json", "schema:shared:hl7v2.message-envelope");
-        writeSchema(dir, "schemas/v251/messages/ADT_A01.json", "schema:table:hl7v2.v251.ADT_A01");
-        writeSchema(dir, "schemas/v251/messages/ORU_R01.json", "schema:table:hl7v2.v251.ORU_R01");
-        writeSchema(dir, "schemas/v251/segments/PID.json", "schema:type:hl7v2.v251.PID");
+        writeSchema(dir, "schemas/v27/messages/ADT_A01.json", "schema:table:hl7v2.v27.ADT_A01");
+        writeSchema(dir, "schemas/v27/messages/ORU_R01.json", "schema:table:hl7v2.v27.ORU_R01");
+        writeSchema(dir, "schemas/v27/segments/PID.json", "schema:type:hl7v2.v27.PID");
 
         BufferStore buffer = new BufferStore(dir.resolve("buffer.db").toString(), false);
         insert(buffer, "M1", "ADT_A01", "ADT", "EPIC", "new", "SMITH");
@@ -45,7 +45,7 @@ class Hl7ProducerIT {
         insert(buffer, "M3", "ORU_R01", "ORU", "CERNER", "new", "BOOTH");
 
         SchemaRegistry schemas = SchemaRegistry.fromDirectory(dir);
-        ObjectTree tree = new ObjectTree(buffer, schemas, "v251");
+        ObjectTree tree = new ObjectTree(buffer, schemas, "v27");
         return new Hl7ProducerFacade(buffer, tree, schemas);
     }
 
@@ -59,7 +59,7 @@ class Hl7ProducerIT {
             String app, String status, String family) throws Exception {
         String json = "{\"pid\":{\"patientFamilyName\":\"" + family + "\"}}";
         b.insert(new BufferRow(0, Instant.parse("2026-05-28T10:00:00Z"), cid, struct, code, "A01",
-            app, "HOSP", "2.5.1", "schema:table:hl7v2.v251." + struct, ("raw-" + cid).getBytes(),
+            app, "HOSP", "2.7", "schema:table:hl7v2.v27." + struct, ("raw-" + cid).getBytes(),
             json, MessageStatus.fromWire(status), null, null, null));
     }
 
@@ -240,9 +240,9 @@ class Hl7ProducerIT {
 
         // unknown schema -> 404, type=schema
         ProducerException e2 = assertThrows(ProducerException.class,
-            () -> op(f, "SchemasApi.getSchema", "objectId", "schema:type:hl7v2.v251.NOPE"));
+            () -> op(f, "SchemasApi.getSchema", "objectId", "schema:type:hl7v2.v27.NOPE"));
         assertEquals(404, e2.httpStatus());
-        assertNoSuchObjectBody(e2.toBody(), "schema", "schema:type:hl7v2.v251.NOPE");
+        assertNoSuchObjectBody(e2.toBody(), "schema", "schema:type:hl7v2.v27.NOPE");
 
         // unknown element key -> 404
         ProducerException e3 = assertThrows(ProducerException.class,

--- a/package/hl7/v2/package-lock.json
+++ b/package/hl7/v2/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zerobias-org/module-hl7-v2",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zerobias-org/module-hl7-v2",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@zerobias-org/module-interface-dataproducer": "^2.1.5",

--- a/package/hl7/v2/package.json
+++ b/package/hl7/v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/module-hl7-v2",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "HL7 v2.x MLLP receiver (DataProducer)",
   "type": "module",
   "moduleId": "369d38b0-2c23-43f0-bbc4-33f453ee75c8",

--- a/package/hl7/v2/runtimeConfig.yml
+++ b/package/hl7/v2/runtimeConfig.yml
@@ -55,9 +55,11 @@ config:
   # the image are active. Extensions are NOT resolved by the platform — they are
   # npm deps baked in at image build (DESIGN §7).
   activeExtensions: []
-  # Target HL7 version for materialization (mirrors connectionProfile.hl7Version
-  # default; the receiver still accepts other versions). (DESIGN §11.5)
-  hl7Version: "2.5.1"
+  # Target HL7 version for materialization — selects the baked-in structure index
+  # (2.7 -> v27). The receiver still accepts any version on the wire; messages of
+  # other versions materialize against this index (partial) or fall back to the
+  # envelope schema. (DESIGN §11.5)
+  hl7Version: "2.7"
   # SQLite durability for the ack path, applied at buffer open. 'normal'
   # (synchronous=NORMAL) is faster; 'full' (synchronous=FULL, fsync per row) is
   # crash-safe for clinical feeds. This is a daemon-level knob set at boot, so it

--- a/package/hl7/v2/runtimeConfig.yml
+++ b/package/hl7/v2/runtimeConfig.yml
@@ -14,13 +14,16 @@
 daemonMode: true
 
 # Extra TCP port the receiver binds beyond the 8888 operations port. Hub Node
-# injects the resolved value as LISTENER_PORT_MLLP. `port: null` = ephemeral
-# (node allocates) — fine for test feeds; operators pin a known port (e.g. 2575)
-# for statically-configured HL7 sources. (DESIGN §3.2, §3.3)
+# injects the resolved value as LISTENER_PORT_MLLP, binds it 1:1 in the container,
+# and maps it 1:1 to the host — so this number IS the address sending systems use.
+# It MUST be prescribed: a daemon MLLP listener with no fixed port is unusable
+# (nobody can know where to connect), which is why we default to 2575 — the
+# IANA-registered HL7-over-MLLP port and the industry default. Operators may
+# override per-deployment if 2575 is taken. (DESIGN §3.2, §3.3)
 listenerPorts:
   - name: mllp
     protocol: tcp
-    port: null
+    port: 2575
     bindAddress: "0.0.0.0"
     tls: false
 


### PR DESCRIPTION
Consolidates the `hl7` branch onto `dev` and supersedes the earlier stale `hl7` commit. Three logical changes + the release bump.

## 1. PagedResults envelope fix (the data-explorer blocker) — `54c40c3`
Expanding any object in the Data Explorer failed with **"Producers must return 'items' for PagedResults queries"**. The paginated producer ops (`getChildren`/`searchChildObjects`/`getCollectionElements`/`searchCollectionElements`) returned a **bare array**, but the platform's generated producer client deserializes the RPC body into a paged bag and throws when `items` is absent (`auditlogic/module/IMPROVEMENTS.md` §PagedResults).

- Wrap both paged methods in `{items, count, pageSize, pageNumber}` with accurate totals.
- `pageNumber` is now 1-based end-to-end (router passes raw, facade does a single `-1`).
- `pagedItems()` test helper asserts the envelope on every paged call + a new `pagedResultsEnvelopeAndPaging` test.

> Note: this supersedes the pagination hunk on the old `hl7` branch, which kept the bare array (so it did **not** clear the error) and double-decremented the page (router `-1` + facade `-1` → page 2+ returned the prior page). Proven on a live container.

## 2. MLLP port 2575 + synthea feeder — `f771a70` (Co-Authored: Kevin)
- `runtimeConfig`: default the mllp `listenerPort` to **2575** (IANA HL7-over-MLLP) instead of `null`.
- Add `java/scripts/synthea_to_mllp.py` (stdlib-only dev feeder; not in `package.json` files[], never ships to npm).

## 3. Move to HL7 v2.7, config-driven — `abc8ea8`
The module targeted v2.5.1 but the structure slot was hardcoded (`VERSION_SLOT="v251"`), so the `hl7Version` field was decorative. This retargets to v2.7 **and** makes the version honest:
- codegen pulls `hapi-structures-v27`; generator + `generate-resources` emit `v27`.
- `ModuleRuntimeConfig.hl7Version` (default `2.7`) drives `versionSlot()` (`2.7`→`v27`); `Hl7ApiServer` derives the slot/materializer/extension-compat from it. Unbaked version → envelope fallback (graceful).
- v2.7 datatype shifts captured in tests + DESIGN: `dateTimeOfBirth` is now a **DTM primitive** (v2.5.1's TS composite retired); `administrativeSex` is a **CWE composite** (was IS).

## 4. Release — `2b1e3b1`
Bump to **1.2.0** + regenerated gate-stamp (`branch: hl7`).

## Validation
- `mvn verify`: **36 unit + 32 integration + 5 codegen**, green.
- Full `zbb gate`: green (`startModuleExec` injected `{mllp=2575}` and booted the container).
- Live container: port 2575 boot, `MSA|AA`, PagedResults envelope on `getChildren /`, and v2.7 shapes (`dateTimeOfBirth` primitive, `administrativeSex` CWE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)