### PR TITLE
feat(module-stellarcyber-stellarcyber): add Stellar Cyber module

### DIFF
--- a/package/stellarcyber/stellarcyber/.gitignore
+++ b/package/stellarcyber/stellarcyber/.gitignore
@@ -1,0 +1,23 @@
+node_modules/
+dist/
+generated/
+hub-sdk/generated/
+hub-sdk/dist/
+hub-sdk/tsconfig.json
+docs/
+build/
+
+# Ephemeral build artifacts
+eslint.config.js
+eslint.config.mjs
+module-*.yml
+full.yml
+redoc-static.html
+test-results.json
+
+# OpenAPI generator artifacts
+.openapi-generator
+.openapi-generator-ignore
+
+# Editor
+*.swp

--- a/package/stellarcyber/stellarcyber/.mocharc.json
+++ b/package/stellarcyber/stellarcyber/.mocharc.json
@@ -1,0 +1,4 @@
+{
+  "extension": ["ts"],
+  "node-option": ["import=tsx/esm"]
+}

--- a/package/stellarcyber/stellarcyber/.npmrc
+++ b/package/stellarcyber/stellarcyber/.npmrc
@@ -1,0 +1,6 @@
+@zerobias-com:registry=https://pkg.zerobias.org
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@devsupply:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/stellarcyber/stellarcyber/.redocly.yaml
+++ b/package/stellarcyber/stellarcyber/.redocly.yaml
@@ -1,0 +1,85 @@
+# Redocly configuration for OpenAPI validation
+# Migrated from Spectral
+
+apis:
+  main:
+    root: ./api.yml
+
+extends:
+  - recommended
+
+rules:
+  # Disabled rules (not applicable to interface definitions)
+  no-empty-servers: off
+  security-defined: off
+  operation-4xx-response: off
+  no-unused-components: off
+  info-contact: off
+  info-license: off
+  operation-description: off
+  tag-description: off
+
+  # Structural rules
+  struct: error
+  no-unresolved-refs: error
+  no-invalid-media-type-examples: warn
+
+  # Operation rules (from Spectral operationMustHaveSummary)
+  operation-summary: error
+  operation-operationId: error
+  operation-operationId-unique: error
+
+  # Schema rules
+  no-invalid-schema-examples: warn
+  boolean-parameter-prefixes: off
+
+  # Path rules
+  no-ambiguous-paths: error
+  no-http-verbs-in-paths: error
+  no-path-trailing-slash: error
+  path-not-include-query: error
+
+  # Parameter rules
+  parameter-description: warn
+
+  # Server rules
+  no-server-example.com: error
+  no-server-trailing-slash: error
+
+  # Custom naming conventions (from Spectral propertyNamesShouldBeCamel)
+  rule/property-names-camelCase:
+    subject:
+      type: SchemaProperties
+    assertions:
+      casing: camelCase
+    severity: error
+    message: Property names must be camelCase.
+
+  rule/parameter-names-camelCase:
+    subject:
+      type: Parameter
+      property: name
+      filterInParentKeys:
+        - query
+        - path
+    assertions:
+      casing: camelCase
+    severity: error
+    message: Parameter names must be camelCase.
+
+  # Properties should have descriptions (from Spectral propertiesShouldHaveDescriptions)
+  rule/properties-have-description:
+    subject:
+      type: Schema
+      property: description
+    where:
+      - subject:
+          type: SchemaProperties
+        assertions:
+          defined: true
+    assertions:
+      defined: true
+    severity: warn
+    message: Properties should have a description.
+
+  # Enums: snake_case disabled per local config

--- a/package/stellarcyber/stellarcyber/README.md
+++ b/package/stellarcyber/stellarcyber/README.md
@@ -1,0 +1,31 @@
+# stellarcyber-stellarcyber Hub Module
+
+ZeroBias Hub module (connector) for **Stellar Cyber** Open XDR. Reads correlated
+threat findings (cases) and their alerts from the Stellar Cyber REST API.
+
+## Authentication and authorization
+
+A scoped **API key** is exchanged for a short-lived (~10 min) JWT bearer at connect
+time (`POST /connect/api/v1/access_token`). Connection profile:
+
+| Field | Description |
+|---|---|
+| `host` | Stellar Cyber console host (e.g. `example.stellarcyber.cloud`), no scheme |
+| `apiToken` | Stellar Cyber scoped API key |
+
+## Operations
+
+| Api | Method | Description |
+|---|---|---|
+| `CaseApi` | `list` | List cases (correlated threat findings) |
+| `CaseApi` | `listAlerts` | List the alerts within a case (resource / threat detail) |
+
+## Build / test
+
+Built via gradle (`zb.typescript-connector`) / `zbb`. Integration tests under
+`test/e2e` skip unless `STELLARCYBER_HOST` + `STELLARCYBER_API_TOKEN` are set.
+
+```bash
+zbb build
+LOG_LEVEL=debug npm run test   # e2e, requires live SC credentials
+```

--- a/package/stellarcyber/stellarcyber/api.yml
+++ b/package/stellarcyber/stellarcyber/api.yml
@@ -166,6 +166,9 @@ components:
         accountId:
           type: string
           description: AWS account id.
+        region:
+          type: string
+          description: AWS region the GuardDuty finding was raised in (used to build the affected-resource ARN).
         arn:
           type: string
           description: GuardDuty finding ARN.
@@ -181,3 +184,6 @@ components:
         resourceType:
           type: string
           description: AWS resource type (e.g. Instance, AccessKey).
+        instanceId:
+          type: string
+          description: EC2 instance id when resourceType is Instance (used to build the affected-resource ARN).

--- a/package/stellarcyber/stellarcyber/api.yml
+++ b/package/stellarcyber/stellarcyber/api.yml
@@ -1,0 +1,183 @@
+openapi: 3.0.3
+info:
+  x-product-infos:
+    - $ref: './node_modules/@zerobias-org/product-stellarcyber-stellarcyber/catalog.yml#/Product'
+  version: '0.0.0'
+  title: '@zerobias-org/module-stellarcyber-stellarcyber'
+  x-impl-name: StellarCyber
+  description: 'Stellar Cyber'
+paths:
+  /cases:
+    get:
+      summary: List Cases
+      description: List Stellar Cyber cases (correlated groups of alerts — threat findings).
+      operationId: listCases
+      x-method-name: list
+      tags:
+        - case
+      parameters:
+        - $ref: '#/components/parameters/pageNumber'
+        - $ref: '#/components/parameters/pageSize'
+        - $ref: '#/components/parameters/caseStatus'
+      responses:
+        '200':
+          description: A list of cases
+          headers:
+            link:
+              $ref: '#/components/headers/pagedLink'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Case'
+  /cases/{caseId}/alerts:
+    get:
+      summary: List Case Alerts
+      description: List the alerts within a case (the resource / threat detail).
+      operationId: listCaseAlerts
+      x-method-name: listAlerts
+      tags:
+        - case
+      parameters:
+        - $ref: '#/components/parameters/caseId'
+        - $ref: '#/components/parameters/pageNumber'
+        - $ref: '#/components/parameters/pageSize'
+      responses:
+        '200':
+          description: A list of case alerts
+          headers:
+            link:
+              $ref: '#/components/headers/pagedLink'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CaseAlert'
+components:
+  headers:
+    pagedLink:
+      $ref: './node_modules/@zerobias-org/types-core/schema/pagedLinkHeader.yml'
+  parameters:
+    pageNumber:
+      $ref: './node_modules/@zerobias-org/types-core/schema/pageNumberParam.yml'
+    pageSize:
+      $ref: './node_modules/@zerobias-org/types-core/schema/pageSizeParam.yml'
+    caseId:
+      name: caseId
+      in: path
+      required: true
+      description: The id of the case.
+      schema:
+        type: string
+    caseStatus:
+      name: status
+      in: query
+      required: false
+      description: Filter cases by status (e.g. New, In Progress, Closed).
+      schema:
+        type: string
+  schemas:
+    Case:
+      type: object
+      description: A Stellar Cyber case — a correlated group of alerts representing a threat finding.
+      properties:
+        id:
+          type: string
+          description: Stellar Cyber case id.
+        name:
+          type: string
+          description: Case title / threat name.
+        severity:
+          type: string
+          description: Case severity (Critical, High, Medium, Low).
+        score:
+          type: number
+          description: Case score.
+        status:
+          type: string
+          description: Case status (e.g. New, In Progress, Closed).
+        size:
+          type: integer
+          description: Number of alerts correlated into the case.
+        createdAt:
+          type: integer
+          format: int64
+          description: Case creation time, in epoch milliseconds.
+        tenantName:
+          type: string
+          description: Stellar Cyber tenant name.
+    CaseAlert:
+      type: object
+      description: An alert within a case, carrying the resource and threat detail.
+      properties:
+        id:
+          type: string
+          description: Alert id.
+        source:
+          $ref: '#/components/schemas/AlertSource'
+    AlertSource:
+      type: object
+      description: The alert detail (Stellar Cyber Interflow record).
+      properties:
+        timestamp:
+          type: string
+          format: date-time
+          description: Alert timestamp.
+        severity:
+          type: integer
+          description: Numeric alert severity (0-100).
+        username:
+          type: string
+          description: Associated username, if any.
+        xdrEvent:
+          $ref: '#/components/schemas/XdrEvent'
+        awsGuardduty:
+          $ref: '#/components/schemas/AwsGuardduty'
+    XdrEvent:
+      type: object
+      description: XDR detection event detail.
+      properties:
+        displayName:
+          type: string
+          description: Detection display name.
+        description:
+          type: string
+          description: Detection description.
+        tactic:
+          $ref: '#/components/schemas/MitreRef'
+        technique:
+          $ref: '#/components/schemas/MitreRef'
+    MitreRef:
+      type: object
+      description: A MITRE ATT&CK tactic or technique reference.
+      properties:
+        id:
+          type: string
+          description: MITRE ATT&CK id.
+        name:
+          type: string
+          description: MITRE ATT&CK name.
+    AwsGuardduty:
+      type: object
+      description: AWS GuardDuty finding context, when the alert derives from GuardDuty.
+      properties:
+        accountId:
+          type: string
+          description: AWS account id.
+        arn:
+          type: string
+          description: GuardDuty finding ARN.
+        type:
+          type: string
+          description: GuardDuty finding type.
+        resource:
+          $ref: '#/components/schemas/AwsGuarddutyResource'
+    AwsGuarddutyResource:
+      type: object
+      description: The AWS resource the GuardDuty finding concerns.
+      properties:
+        resourceType:
+          type: string
+          description: AWS resource type (e.g. Instance, AccessKey).

--- a/package/stellarcyber/stellarcyber/build.gradle.kts
+++ b/package/stellarcyber/stellarcyber/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    id("zb.typescript-connector")
+}

--- a/package/stellarcyber/stellarcyber/connectionProfile.yml
+++ b/package/stellarcyber/stellarcyber/connectionProfile.yml
@@ -1,0 +1,14 @@
+type: object
+required:
+  - host
+  - apiToken
+properties:
+  host:
+    type: string
+    description: Stellar Cyber console host (e.g. example.stellarcyber.cloud), without scheme.
+    example: example.stellarcyber.cloud
+  apiToken:
+    type: string
+    format: password
+    description: Stellar Cyber scoped API key. Exchanged for a short-lived JWT bearer at connect time.
+    example: AYjcyMzY3ZDhiNmJkNTY

--- a/package/stellarcyber/stellarcyber/hub-sdk/package.json
+++ b/package/stellarcyber/stellarcyber/hub-sdk/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@zerobias-org/hub-sdk-stellarcyber-stellarcyber",
+  "version": "0.0.0",
+  "description": "Hub SDK for Stellar Cyber module",
+  "type": "module",
+  "main": "dist/api/index.js",
+  "types": "dist/api/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/api/index.d.ts",
+      "import": "./dist/api/index.js"
+    },
+    "./api": {
+      "types": "./dist/api/index.d.ts",
+      "import": "./dist/api/index.js"
+    },
+    "./model": {
+      "types": "./dist/model/index.d.ts",
+      "import": "./dist/model/index.js"
+    }
+  },
+  "files": ["dist"],
+  "peerDependencies": {
+    "@zerobias-org/types-core-js": "^1.2.19",
+    "@zerobias-org/util-connector": "^1.0.40",
+    "axios": "^1.0.0"
+  },
+  "publishConfig": { "access": "restricted" }
+}

--- a/package/stellarcyber/stellarcyber/package.json
+++ b/package/stellarcyber/stellarcyber/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@zerobias-org/module-stellarcyber-stellarcyber",
+  "version": "0.0.0",
+  "description": "Stellar Cyber",
+  "moduleId": "61644b62-0621-4df6-b5c2-4ea2c4e2a9c7",
+  "type": "module",
+  "main": "dist/src/index.js",
+  "author": "team@zerobias.com",
+  "license": "UNLICENSED",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zerobias-org/module",
+    "directory": "package/stellarcyber/stellarcyber"
+  },
+  "publishConfig": {
+    "registry": "https://pkg.zerobias.org/"
+  },
+  "scripts": {
+    "clean": "rm -rf build/ dist/ generated/ hub-sdk/generated hub-sdk/tsconfig.json hub-sdk/dist module-stellarcyber-stellarcyber.yml full.yml"
+  },
+  "files": [
+    "dist",
+    "generated/api/manifest.json",
+    "api.yml",
+    "connectionProfile.yml"
+  ],
+  "zerobias": {
+    "package": "stellarcyber.stellarcyber.module",
+    "dataloader-version": "1.0.0",
+    "import-artifact": "module"
+  },
+  "overrides": {
+    "diff": ">=8.0.3",
+    "serialize-javascript": ">=7.0.3"
+  },
+  "dependencies": {
+    "@zerobias-org/logger": "^3.0.9",
+    "@zerobias-org/product-stellarcyber-stellarcyber": "latest",
+    "@zerobias-org/util-connector": "^1.0.40",
+    "@zerobias-org/util-hub-module-utils": "^2.0.49",
+    "axios": "1.15.0"
+  },
+  "peerDependencies": {
+    "@zerobias-org/types-core": "^1.0.24",
+    "@zerobias-org/types-core-js": "^1.2.23"
+  },
+  "devDependencies": {
+    "@redocly/cli": "2.28.1",
+    "@types/chai": "4.3.20",
+    "@types/mocha": "10.0.10",
+    "@types/node": "22.19.17",
+    "@zerobias-org/eslint-config": "^1.0.38",
+    "@zerobias-org/module-test-client": "^1.0.5",
+    "@zerobias-org/util-api-client-base": "^1.0.44",
+    "@zerobias-org/util-codegen": "^2.0.49",
+    "chai": "4.5.0",
+    "mocha": "11.7.5",
+    "tsx": "4.21.0",
+    "typescript": "5.9.3"
+  }
+}

--- a/package/stellarcyber/stellarcyber/src/CaseProducerImpl.ts
+++ b/package/stellarcyber/stellarcyber/src/CaseProducerImpl.ts
@@ -1,0 +1,49 @@
+import { PagedResults } from '@zerobias-org/types-core-js';
+import { CaseProducerApi } from '../generated/api/index.js';
+import { Case, CaseAlert } from '../generated/model/index.js';
+import { StellarCyberClient } from './StellarCyberClient.js';
+import { handleAxiosError } from './util.js';
+import { toCase, toCaseAlert } from './mappers.js';
+
+export class CaseProducerImpl implements CaseProducerApi {
+  constructor(private client: StellarCyberClient) {}
+
+  async list(results: PagedResults<Case>, status?: string): Promise<void> {
+    const { apiClient } = this.client;
+
+    const { data } = await apiClient
+      .request({
+        url: '/cases',
+        method: 'get',
+        params: {
+          limit: results.pageSize,
+          status,
+        },
+      })
+      .catch(handleAxiosError);
+
+    // SC may return {cases:[...]}, {data:{cases:[...]}}, or a bare array.
+    const cases = data?.cases ?? data?.data?.cases ?? (Array.isArray(data) ? data : []);
+    return results.ingest(cases.map((c: any) => toCase(c)));
+  }
+
+  async listAlerts(results: PagedResults<CaseAlert>, caseId: string): Promise<void> {
+    const { apiClient } = this.client;
+
+    const skip = results.pageSize * (results.pageNumber - 1);
+    const { data } = await apiClient
+      .request({
+        url: `/cases/${caseId}/alerts`,
+        method: 'get',
+        // SC requires both skip and limit, or it returns 422.
+        params: {
+          skip,
+          limit: results.pageSize,
+        },
+      })
+      .catch(handleAxiosError);
+
+    const docs = data?.docs ?? data?.alerts ?? data?.data?.docs ?? (Array.isArray(data) ? data : []);
+    return results.ingest(docs.map((a: any) => toCaseAlert(a)));
+  }
+}

--- a/package/stellarcyber/stellarcyber/src/StellarCyberClient.ts
+++ b/package/stellarcyber/stellarcyber/src/StellarCyberClient.ts
@@ -1,0 +1,78 @@
+import {
+  ConnectionMetadata,
+  ConnectionStatus,
+  InvalidCredentialsError,
+  NotConnectedError,
+  OperationSupportStatus,
+  OperationSupportStatusDef
+} from '@zerobias-org/types-core-js';
+import axios, { AxiosInstance } from 'axios';
+import { ConnectionProfile } from '../generated/model/ConnectionProfile.js';
+
+/**
+ * Stellar Cyber REST client.
+ *
+ * Auth: a scoped API key is exchanged for a short-lived (~10 min) JWT bearer at
+ * connect time (`POST /access_token`). The JWT is held in-memory for the lifetime
+ * of the connection; a collector run completes well within the token window, and
+ * the platform re-connects (re-exchanges the key) for a fresh scope/run.
+ */
+export class StellarCyberClient {
+  private _apiClient?: AxiosInstance;
+
+  private _jwt?: string;
+
+  public get apiClient(): AxiosInstance {
+    if (!this._jwt || !this._apiClient) {
+      throw new NotConnectedError();
+    }
+    return this._apiClient;
+  }
+
+  async connect(connectionProfile: ConnectionProfile): Promise<void> {
+    if (!connectionProfile.apiToken || !connectionProfile.host) {
+      throw new InvalidCredentialsError();
+    }
+
+    const host = connectionProfile.host.replace(/^https?:\/\//, '').replace(/\/+$/, '');
+    const baseURL = `https://${host}/connect/api/v1`;
+
+    // Exchange the scoped API key for a short-lived JWT bearer.
+    const { data } = await axios.request({
+      url: `${baseURL}/access_token`,
+      method: 'post',
+      headers: { Authorization: `Bearer ${connectionProfile.apiToken}` },
+      validateStatus: (status) => status >= 200 && status < 300,
+    });
+
+    this._jwt = data?.access_token;
+    if (!this._jwt) {
+      throw new InvalidCredentialsError();
+    }
+
+    this._apiClient = axios.create({
+      baseURL,
+      headers: { Authorization: `Bearer ${this._jwt}` },
+      validateStatus: (status) => status >= 200 && status < 300,
+    });
+  }
+
+  async isConnected(): Promise<boolean> {
+    return !!this._jwt;
+  }
+
+  async disconnect(): Promise<void> {
+    this._jwt = undefined;
+    this._apiClient = undefined;
+  }
+
+
+  async metadata(): Promise<ConnectionMetadata> {
+    return new ConnectionMetadata(ConnectionStatus.Down);
+  }
+
+
+  async isSupported(_operationId: string): Promise<OperationSupportStatusDef> {
+    return OperationSupportStatus.Maybe;
+  }
+}

--- a/package/stellarcyber/stellarcyber/src/StellarCyberImpl.ts
+++ b/package/stellarcyber/stellarcyber/src/StellarCyberImpl.ts
@@ -1,0 +1,40 @@
+import {
+  ConnectionMetadata,
+  OperationSupportStatusDef
+} from '@zerobias-org/types-core-js';
+import {
+  CaseApi,
+  StellarCyberConnector,
+  wrapCaseProducer
+} from '../generated/api/index.js';
+import { ConnectionProfile } from '../generated/model/index.js';
+import { CaseProducerImpl } from './CaseProducerImpl.js';
+import { StellarCyberClient } from './StellarCyberClient.js';
+
+export class StellarCyberImpl implements StellarCyberConnector {
+  private client = new StellarCyberClient();
+
+  async connect(connectionProfile: ConnectionProfile): Promise<void> {
+    return this.client.connect(connectionProfile);
+  }
+
+  async isConnected(): Promise<boolean> {
+    return this.client.isConnected();
+  }
+
+  async disconnect(): Promise<void> {
+    return this.client.disconnect();
+  }
+
+  async metadata(): Promise<ConnectionMetadata> {
+    return this.client.metadata();
+  }
+
+  async isSupported(operationId: string): Promise<OperationSupportStatusDef> {
+    return this.client.isSupported(operationId);
+  }
+
+  getCaseApi(): CaseApi {
+    return wrapCaseProducer(new CaseProducerImpl(this.client));
+  }
+}

--- a/package/stellarcyber/stellarcyber/src/index.ts
+++ b/package/stellarcyber/stellarcyber/src/index.ts
@@ -1,0 +1,10 @@
+import { StellarCyberConnector } from '../generated/api/index.js';
+import { StellarCyberImpl } from './StellarCyberImpl.js';
+
+export * from '../generated/api/index.js';
+export * from '../generated/model/index.js';
+
+/** Factory function — the primary entry point for creating module instances. */
+export function newStellarCyber(): StellarCyberConnector {
+  return new StellarCyberImpl();
+}

--- a/package/stellarcyber/stellarcyber/src/mappers.ts
+++ b/package/stellarcyber/stellarcyber/src/mappers.ts
@@ -1,0 +1,50 @@
+import { Case, CaseAlert } from '../generated/model/index.js';
+
+/**
+ * Stellar Cyber returns underscore-prefixed/snake_case JSON (`_id`, `_source`,
+ * `xdr_event`, `aws_guardduty`, `AccountId`, …). The generated models are
+ * camelCase, so these mappers normalise the raw API shapes into model instances.
+ */
+
+export function toCase(raw: any): Case {
+  const data = typeof raw === 'string' ? JSON.parse(raw) : raw;
+  return Case.newInstance({
+    id: data._id ?? data.id,
+    name: data.name,
+    severity: data.severity,
+    score: data.score,
+    status: data.status,
+    size: data.size,
+    createdAt: data.created_at ?? data.createdAt ?? data.start_timestamp,
+    tenantName: data.tenant_name ?? data.tenantName,
+  });
+}
+
+export function toCaseAlert(raw: any): CaseAlert {
+  const data = typeof raw === 'string' ? JSON.parse(raw) : raw;
+  const src = data._source ?? data.source ?? {};
+  const xdr = src.xdr_event ?? src.xdrEvent ?? {};
+  const gd = src.aws_guardduty ?? src.awsGuardduty ?? {};
+  const res = gd.Resource ?? gd.resource ?? {};
+
+  return CaseAlert.newInstance({
+    id: data._id ?? data.id,
+    source: {
+      timestamp: src['@timestamp'] ?? src.timestamp,
+      severity: src.severity,
+      username: src.username,
+      xdrEvent: {
+        displayName: xdr.display_name ?? xdr.displayName,
+        description: xdr.description,
+        tactic: xdr.tactic && { id: xdr.tactic.id, name: xdr.tactic.name },
+        technique: xdr.technique && { id: xdr.technique.id, name: xdr.technique.name },
+      },
+      awsGuardduty: {
+        accountId: gd.AccountId ?? gd.accountId,
+        arn: gd.Arn ?? gd.arn,
+        type: gd.Type ?? gd.type,
+        resource: { resourceType: res.ResourceType ?? res.resourceType },
+      },
+    },
+  });
+}

--- a/package/stellarcyber/stellarcyber/src/mappers.ts
+++ b/package/stellarcyber/stellarcyber/src/mappers.ts
@@ -26,6 +26,7 @@ export function toCaseAlert(raw: any): CaseAlert {
   const xdr = src.xdr_event ?? src.xdrEvent ?? {};
   const gd = src.aws_guardduty ?? src.awsGuardduty ?? {};
   const res = gd.Resource ?? gd.resource ?? {};
+  const instanceDetails = res.InstanceDetails ?? res.instanceDetails ?? {};
 
   return CaseAlert.newInstance({
     id: data._id ?? data.id,
@@ -41,9 +42,13 @@ export function toCaseAlert(raw: any): CaseAlert {
       },
       awsGuardduty: {
         accountId: gd.AccountId ?? gd.accountId,
+        region: gd.Region ?? gd.region,
         arn: gd.Arn ?? gd.arn,
         type: gd.Type ?? gd.type,
-        resource: { resourceType: res.ResourceType ?? res.resourceType },
+        resource: {
+          resourceType: res.ResourceType ?? res.resourceType,
+          instanceId: instanceDetails.InstanceId ?? instanceDetails.instanceId ?? res.instanceId,
+        },
       },
     },
   });

--- a/package/stellarcyber/stellarcyber/src/util.ts
+++ b/package/stellarcyber/stellarcyber/src/util.ts
@@ -1,0 +1,16 @@
+import { InvalidInputError, NotFoundError } from '@zerobias-org/types-core-js';
+import { AxiosError } from 'axios';
+
+export function handleAxiosError(e: AxiosError): never {
+  const errStatus = `${e.status || e.response?.status}`;
+
+  if (errStatus === '400') {
+    throw new InvalidInputError(`${e.response?.data}`, e.response?.data);
+  } else if (errStatus === '404') {
+    throw new NotFoundError(`${e.response?.data}`);
+  }
+
+  console.log(e);
+
+  throw new Error('Error handler not implemented yet');
+}

--- a/package/stellarcyber/stellarcyber/test/e2e/constants.ts
+++ b/package/stellarcyber/stellarcyber/test/e2e/constants.ts
@@ -1,0 +1,7 @@
+export const STELLARCYBER_HOST = process.env.STELLARCYBER_HOST ?? '';
+export const STELLARCYBER_API_TOKEN = process.env.STELLARCYBER_API_TOKEN ?? '';
+export const STELLARCYBER_CASE_ID = process.env.STELLARCYBER_CASE_ID ?? '';
+
+export function hasCredentials(): boolean {
+  return !!STELLARCYBER_HOST && !!STELLARCYBER_API_TOKEN;
+}

--- a/package/stellarcyber/stellarcyber/test/e2e/stellarcyber.test.ts
+++ b/package/stellarcyber/stellarcyber/test/e2e/stellarcyber.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Stellar Cyber Module E2E Tests.
+ *
+ * The describeModule framework owns the connect/isConnected/disconnect
+ * lifecycle, so those paths are not re-exercised here. Skips unless live
+ * Stellar Cyber credentials (STELLARCYBER_HOST + STELLARCYBER_API_TOKEN) are set.
+ */
+
+import { expect } from 'chai';
+import { CoreError } from '@zerobias-org/types-core-js';
+import { describeModule } from '@zerobias-org/module-test-client';
+import type { StellarCyber } from '../../hub-sdk/generated/api/index.js';
+import { STELLARCYBER_CASE_ID, hasCredentials } from './constants.js';
+
+describeModule<StellarCyber>('Stellar Cyber Module', (client) => {
+
+  before(function () {
+    if (!hasCredentials()) {
+      this.skip();
+    }
+  });
+
+  describe('CaseApi.list', () => {
+    it('should list cases', async () => {
+      const results = await client.getCaseApi().list();
+      expect(results).to.be.ok;
+    });
+  });
+
+  describe('CaseApi.listAlerts', () => {
+    it('should list alerts for a case', async function () {
+      if (!STELLARCYBER_CASE_ID) {
+        this.skip();
+      }
+      const results = await client.getCaseApi().listAlerts(STELLARCYBER_CASE_ID);
+      expect(results).to.be.ok;
+    });
+  });
+
+}, (data) => CoreError.deserialize(data));

--- a/package/stellarcyber/stellarcyber/tsconfig.json
+++ b/package/stellarcyber/stellarcyber/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noImplicitAny": false,
+    "target": "ES2022",
+    "strict": true,
+    "sourceMap": true,
+    "declaration": true,
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "useUnknownInCatchVariables": false
+  },
+  "include": ["src/**/*", "test/**/*", "generated/**/*"],
+  "exclude": ["dist", "node_modules", "hub-sdk"]
+}


### PR DESCRIPTION
## Summary
New ZeroBias **Hub module** (connector) for **Stellar Cyber** Open XDR — the SC API client layer of the connector chain. It reads correlated threat findings (cases) and their alerts from the Stellar Cyber REST API.

This is the productized form of the working `sc-to-zb.py` reader (`SC` class: scoped API key -> JWT -> `/cases`, `/cases/{id}/alerts`).

## Auth
Scoped **API key** exchanged for a short-lived (~10 min) JWT bearer at connect time (`POST /connect/api/v1/access_token`). Connection profile: `host` + `apiToken`.

## Operations (`CaseApi`)
- `list` — list cases (correlated threat findings)
- `listAlerts` — list the alerts within a case (resource / threat detail)

## Files
`api.yml` (ops + `Case`/`CaseAlert`/`AlertSource`/`XdrEvent`/`AwsGuardduty` models), `connectionProfile.yml`, `src/StellarCyberClient.ts` (the API-key->JWT connect), `CaseProducerImpl.ts`, `StellarCyberImpl.ts`, `mappers.ts`, `util.ts`, plus the standard `package.json`/`tsconfig`/`.mocharc`/`.redocly`/`hub-sdk`/e2e test scaffolding. Modeled file-by-file on the `readyplayerme` sibling.

## Dependency / order
Depends on **`@zerobias-org/product-stellarcyber-stellarcyber`** (PR zerobias-org/product#34) — `api.yml` `$ref`s its `catalog.yml`. That product (and its vendor, zerobias-org/vendor#76) must publish first.

## Validation
- [x] gradle configures the project (`:stellarcyber:stellarcyber`), plugin resolves
- [x] `npm install` succeeds (with the product dep present) and `assembleSpec` consumes `api.yml`
- [ ] full `bundleSpec` -> codegen -> `tsc` compile + `gate` — run in **CI** (local bundle blocked only by a WSL `/mnt/c` symlink/permission quirk reading `generated/node_modules`, not the code; needs the product published)
- [ ] integration tests (`test/e2e`) — need live Stellar Cyber credentials

## Part of the connector chain
vendor (zerobias-org/vendor#76) + product (zerobias-org/product#34) done; **module (this PR)**; schema (`StellarCyberFinding`) and collectorbot (map + push) follow.

Generated with Claude Code.