### PR TITLE
feat(dataproducer): add checksum field to Object for content change detection

### DIFF
--- a/package/interface/dataproducer/api.yml
+++ b/package/interface/dataproducer/api.yml
@@ -828,6 +828,14 @@ components:
           type: integer
           format: int64
           description: Content size in bytes (binary objects only)
+        checksum:
+          type: string
+          description: >-
+            Content digest that changes if and only if the object's content
+            changes. Used for change detection (e.g. deciding whether to
+            re-fetch a copy). Opaque, source-defined value (e.g. git blob SHA,
+            S3 ETag, content hash); compare for equality only. Distinct from
+            etag, which is a metadata entity tag for optimistic concurrency.
     ObjectClass:
       type: string
       description: Object capability indicator

--- a/package/interface/dataproducer/documentation/Concepts.md
+++ b/package/interface/dataproducer/documentation/Concepts.md
@@ -31,7 +31,8 @@ deviations between the two should be treated as bugs in `api.yml`.
 | `tags`        | string[]    | no       | Organizational tags. |
 | `created`     | date-time   | no       | Creation timestamp. |
 | `modified`    | date-time   | no       | Last modification timestamp. |
-| `etag`        | string      | no       | Used with `If-Match` for optimistic concurrency on writes. |
+| `etag`        | string      | no       | Used with `If-Match` for optimistic concurrency on writes. A *metadata* entity tag — not a content digest. |
+| `checksum`    | string      | no       | Content digest that changes iff the object's content changes. Used for change detection (e.g. deciding whether to re-fetch a copy). Opaque, source-defined value (git blob SHA, S3 ETag, content hash, …); compare for equality only. |
 | `versionId`   | string      | no       | Version pointer when the underlying source supports versioning. |
 | `objectClass` | ObjectClass[] | no     | Capability indicators (see next section). |
 
@@ -57,6 +58,21 @@ Writes that modify an existing object (`updateObject`, `updateCollectionElement`
 `updateDocumentData`) accept an `If-Match` header carrying the `etag` last
 observed by the caller. Implementations that support concurrency control must
 reject mismatched ETags with `412 Precondition Failed`.
+
+### Content Change Detection
+
+`checksum` is the contract for detecting whether an object's *content* has
+changed, independent of metadata. Consumers (e.g. a file copy that decides
+whether to re-fetch) compare the `checksum` they last observed against the
+current one and re-fetch only on mismatch.
+
+Implementations populate `checksum` from whatever value the underlying source
+exposes that changes iff content changes — a git blob SHA, an S3 ETag, a
+`quickXorHash`, etc. The value is opaque and source-defined: compare it for
+equality, never parse or assume an algorithm. Keep it stable across reads of
+unchanged content. This is deliberately separate from `etag`, which tracks
+*metadata* identity for optimistic concurrency and may change without the
+content changing.
 
 ## ObjectClass
 

--- a/package/interface/dataproducer/gate-stamp.json
+++ b/package/interface/dataproducer/gate-stamp.json
@@ -1,7 +1,7 @@
 {
-  "version": "2.1.5",
-  "branch": "main",
-  "sourceHash": "8bd40ad905d5dfe9efa3f26c9ed35bb7023e3275d9441ec8ee0c256f400481f1",
+  "version": "2.2.0-uat.0",
+  "branch": "dataproducer-checksum",
+  "sourceHash": "4654ab179d188f825279628886a330ceac2bb849789abb45526a8d0c0cfda2e6",
   "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "tasks": {
     "validate": "passed",

--- a/package/interface/dataproducer/package-lock.json
+++ b/package/interface/dataproducer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zerobias-org/module-interface-dataproducer",
-  "version": "2.1.4",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zerobias-org/module-interface-dataproducer",
-      "version": "2.1.4",
+      "version": "2.2.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@zerobias-org/product-zerobias-zerobias": "latest",

--- a/package/interface/dataproducer/package.json
+++ b/package/interface/dataproducer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/module-interface-dataproducer",
-  "version": "2.1.5",
+  "version": "2.2.0",
   "description": "Dynamic Data Producer Interface",
   "moduleId": "a2b032b3-eb87-4cb8-8916-8fbbd4c3fcef",
   "type": "module",


### PR DESCRIPTION
## What

Adds an optional `checksum` field to the DataProducer `Object` schema.

`checksum` is an opaque, source-defined content digest that changes **iff** the object's content changes (git blob SHA, S3 ETag, content hash, …). Consumers compare it for equality to decide whether content changed — e.g. `fileservice.copy()` deciding whether to re-fetch.

This restores the content-change-detection capability that was lost in the move to the DataProducer model. It is deliberately **separate from `etag`**: `etag` is a *metadata* entity tag for optimistic concurrency (`If-Match`) and can change without the content changing.

## Why a dedicated field (not overloading `etag`)

Per the discussion: rather than overloading `etag` with content hashes, modules now set a real content digest in `checksum`. `etag` keeps its concurrency-control meaning.

## Notes

- Placed as the **trailing** property so the generated `ModelObject` constructor's positional args stay backward-compatible (`etag` #9, `versionId` #10, … unchanged; `checksum` is the new last arg). Inserting mid-list would have silently shifted every existing positional builder call.
- Canonical docs (`documentation/Concepts.md`) updated to match — field table row + a "Content Change Detection" subsection.
- Version bump 2.1.5 → 2.2.0.
- Gate passed against a Neon branch off `content-master`; `gate-stamp.json` committed.

## Downstream (follow-up, not in this PR)

Once published, module builders set `checksum` for files: github (`content.sha`), msgraph (`cTag`/`quickXorHash`), s3 (`ETag`), confluence (version), jira (attachment id). Plus filling `size`/`mimeType` where undefined.