### PR TITLE
feat(hl7-v2): multi-version structure support (+ ISO-datetime filters, ops/recast)

### DIFF
--- a/package/hl7/v2/gate-stamp.json
+++ b/package/hl7/v2/gate-stamp.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.2.1",
-  "branch": "hl7_runtime_config",
+  "version": "1.2.1-uat.0",
+  "branch": "hl7_multi_version",
   "sourceHash": "c6a1fdddd55bed7060b65585b845626fcda7294a37ca3d34e90cea7e75b1a648",
   "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "tasks": {

--- a/package/hl7/v2/java/codegen/pom.xml
+++ b/package/hl7/v2/java/codegen/pom.xml
@@ -44,9 +44,40 @@
             <artifactId>hapi-base</artifactId>
             <version>${hapi.version}</version>
         </dependency>
-        <!-- The typed model classes the generator reflects over. The module targets
-             HL7 v2.7 (ca.uhn.hl7v2.model.v27.*); add more versions here
-             (hapi-structures-v251, -v25, ...) if we re-introduce them. -->
+        <!-- The typed model classes the generator reflects over — BUILD-TIME ONLY
+             (they never ship; the runtime serves the generated JSON). One artifact
+             per supported HL7 version slot; the generator enumerates every message
+             structure in each version's model.message package (general-purpose). -->
+        <dependency>
+            <groupId>ca.uhn.hapi</groupId>
+            <artifactId>hapi-structures-v23</artifactId>
+            <version>${hapi.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ca.uhn.hapi</groupId>
+            <artifactId>hapi-structures-v231</artifactId>
+            <version>${hapi.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ca.uhn.hapi</groupId>
+            <artifactId>hapi-structures-v24</artifactId>
+            <version>${hapi.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ca.uhn.hapi</groupId>
+            <artifactId>hapi-structures-v25</artifactId>
+            <version>${hapi.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ca.uhn.hapi</groupId>
+            <artifactId>hapi-structures-v251</artifactId>
+            <version>${hapi.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ca.uhn.hapi</groupId>
+            <artifactId>hapi-structures-v26</artifactId>
+            <version>${hapi.version}</version>
+        </dependency>
         <dependency>
             <groupId>ca.uhn.hapi</groupId>
             <artifactId>hapi-structures-v27</artifactId>

--- a/package/hl7/v2/java/codegen/src/main/java/com/zerobias/module/hl7/codegen/HapiNames.java
+++ b/package/hl7/v2/java/codegen/src/main/java/com/zerobias/module/hl7/codegen/HapiNames.java
@@ -1,5 +1,6 @@
 package com.zerobias.module.hl7.codegen;
 
+import java.util.Locale;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -39,6 +40,40 @@ public final class HapiNames {
         }
         final int index = Integer.parseInt(m.group(2));
         return Optional.of(new Accessor(index, decapitalize(m.group(3))));
+    }
+
+    /**
+     * HAPI's method-name prefix for a structure simple name: capitalize the first
+     * char, lowercase the rest ({@code "GT1" -> "Gt1"}, {@code "PID" -> "Pid"},
+     * {@code "CX" -> "Cx"}). This mirrors how HAPI builds {@code get<Prefix><N>_<Bean>}.
+     */
+    public static String accessorPrefix(String structureSimpleName) {
+        if (structureSimpleName == null || structureSimpleName.isEmpty()) {
+            return structureSimpleName;
+        }
+        return Character.toUpperCase(structureSimpleName.charAt(0))
+            + structureSimpleName.substring(1).toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * Parse a positional accessor when the structure's <em>exact</em> accessor
+     * prefix is known. The generic {@link #parseAccessor(String)} guesses the
+     * alpha/number split, which is ambiguous for segments whose name ends in a
+     * digit ({@code getGt11_...} is GT1 field 1, not a "Gt" field 11) — folding the
+     * trailing digit into the index and colliding fields 1-9 with 11-19. Anchoring
+     * on the known prefix removes the ambiguity.
+     */
+    public static Optional<Accessor> parseAccessor(String methodName, String accessorPrefix) {
+        if (methodName == null || accessorPrefix == null || accessorPrefix.isEmpty()) {
+            return Optional.empty();
+        }
+        final Matcher m = Pattern
+            .compile("^get" + Pattern.quote(accessorPrefix) + "(\\d+)_([A-Za-z0-9]+)$")
+            .matcher(methodName);
+        if (!m.matches()) {
+            return Optional.empty();
+        }
+        return Optional.of(new Accessor(Integer.parseInt(m.group(1)), decapitalize(m.group(2))));
     }
 
     /**

--- a/package/hl7/v2/java/codegen/src/main/java/com/zerobias/module/hl7/codegen/SchemaGenerator.java
+++ b/package/hl7/v2/java/codegen/src/main/java/com/zerobias/module/hl7/codegen/SchemaGenerator.java
@@ -7,13 +7,19 @@ import com.zerobias.module.hl7.codegen.model.Property;
 import com.zerobias.module.hl7.codegen.model.Reference;
 import com.zerobias.module.hl7.codegen.model.Schema;
 
+import java.net.JarURLConnection;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Enumeration;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
 
 /**
  * Build-time schema generator (DESIGN §6).
@@ -63,19 +69,77 @@ public final class SchemaGenerator {
             System.exit(2);
             return;
         }
-        final String version = args[0];
+        // arg0 is one version slot or a comma-separated list (e.g. "v23,v24,v27"),
+        // so the whole supported set is generated in a single JVM invocation.
+        final String[] versions = args[0].split(",");
         final Path outputDir = Path.of(args[1]);
-        final String[] msgs = args.length > 2
+        final String[] requested = args.length > 2
             ? java.util.Arrays.copyOfRange(args, 2, args.length)
             : DEFAULT_MESSAGES;
+        final boolean all = requested.length == 1
+            && ("ALL".equalsIgnoreCase(requested[0]) || "*".equals(requested[0]));
 
-        new SchemaGenerator(version, outputDir).run(msgs);
+        for (String version : versions) {
+            // "ALL"/"*" → enumerate every message structure the version ships.
+            final String[] msgs = all
+                ? enumerateMessages(version).toArray(new String[0])
+                : requested;
+            new SchemaGenerator(version, outputDir).run(msgs);
+        }
+    }
+
+    /**
+     * Every message-structure simple name HAPI ships for {@code version}, read from
+     * the {@code ca.uhn.hl7v2.model.<version>.message} package on the classpath
+     * (the {@code hapi-structures-<version>} jar). Inner classes ({@code $}) are
+     * skipped; the walk from each message transitively discovers its groups,
+     * segments, datatypes, and tables.
+     */
+    private static List<String> enumerateMessages(String version) throws Exception {
+        final String pkgPath = "ca/uhn/hl7v2/model/" + version + "/message";
+        final Set<String> names = new TreeSet<>();
+        final Enumeration<URL> roots =
+            Thread.currentThread().getContextClassLoader().getResources(pkgPath);
+        while (roots.hasMoreElements()) {
+            final URL url = roots.nextElement();
+            if (!"jar".equals(url.getProtocol())) {
+                continue;   // HAPI structures always ship as jars
+            }
+            final JarURLConnection conn = (JarURLConnection) url.openConnection();
+            conn.setUseCaches(false);
+            try (JarFile jar = conn.getJarFile()) {
+                final Enumeration<JarEntry> entries = jar.entries();
+                while (entries.hasMoreElements()) {
+                    final String n = entries.nextElement().getName();
+                    if (n.startsWith(pkgPath + "/") && n.endsWith(".class") && !n.contains("$")) {
+                        names.add(n.substring((pkgPath + "/").length(), n.length() - ".class".length()));
+                    }
+                }
+            }
+        }
+        if (names.isEmpty()) {
+            throw new IllegalStateException("no message structures found for " + version
+                + " (is hapi-structures-" + version + " on the classpath?)");
+        }
+        return new ArrayList<>(names);
     }
 
     private void run(String[] messageSimpleNames) throws Exception {
         final StructureWalker walker = new StructureWalker(version);
+        int skipped = 0;
         for (String msg : messageSimpleNames) {
-            walker.walkMessage(msg);
+            try {
+                walker.walkMessage(msg);
+            } catch (Exception | LinkageError e) {
+                // One non-instantiable/oddball structure must not fail a whole-catalog
+                // build; record and continue (DESIGN §6 general-purpose codegen).
+                skipped++;
+                System.err.printf("  skip %s.%s: %s%n", version, msg, e);
+            }
+        }
+        if (skipped > 0) {
+            System.err.printf("Skipped %d/%d message structures for %s.%n",
+                skipped, messageSimpleNames.length, version);
         }
 
         // Message table schemas carry the HL7 structure + the buffer envelope (DESIGN §2.3).

--- a/package/hl7/v2/java/codegen/src/main/java/com/zerobias/module/hl7/codegen/StructureWalker.java
+++ b/package/hl7/v2/java/codegen/src/main/java/com/zerobias/module/hl7/codegen/StructureWalker.java
@@ -223,11 +223,12 @@ public final class StructureWalker {
      */
     private static Map<Integer, String> positionalBeanNames(Class<?> structureClass) {
         final Map<Integer, String> map = new HashMap<>();
+        final String prefix = HapiNames.accessorPrefix(structureClass.getSimpleName());
         for (Method m : structureClass.getMethods()) {
             if (!returnsHl7Type(m)) {
                 continue;
             }
-            HapiNames.parseAccessor(m.getName())
+            HapiNames.parseAccessor(m.getName(), prefix)
                 .ifPresent(a -> map.putIfAbsent(a.index(), a.beanName()));
         }
         return map;

--- a/package/hl7/v2/java/codegen/src/test/java/com/zerobias/module/hl7/codegen/PureHelpersTest.java
+++ b/package/hl7/v2/java/codegen/src/test/java/com/zerobias/module/hl7/codegen/PureHelpersTest.java
@@ -43,6 +43,29 @@ class PureHelpersTest {
     }
 
     @Test
+    void prefixAnchoredParsingHandlesDigitEndingSegments() {
+        // GT1 (accessor prefix "Gt1"): the generic parser splits getGt11_ as
+        // "Gt" + index 11 (folding the segment's trailing 1 into the index), which
+        // collides fields 1-9 with 11-19. Prefix-anchored parsing keeps them apart.
+        assertEquals("Gt1", HapiNames.accessorPrefix("GT1"));
+        assertEquals("Pid", HapiNames.accessorPrefix("PID"));
+        assertEquals("Cx", HapiNames.accessorPrefix("CX"));
+
+        var gt1_1 = HapiNames.parseAccessor("getGt11_SetIDGT1", "Gt1").orElseThrow();
+        assertEquals(1, gt1_1.index());
+        assertEquals("setIDGT1", gt1_1.beanName());
+
+        var gt1_11 = HapiNames.parseAccessor("getGt111_GuarantorRelationship", "Gt1").orElseThrow();
+        assertEquals(11, gt1_11.index());
+        assertEquals("guarantorRelationship", gt1_11.beanName());
+
+        // Non-digit-ending segments still resolve against their own prefix.
+        assertEquals(3, HapiNames.parseAccessor("getPid3_PatientIdentifierList", "Pid").orElseThrow().index());
+        // A method for a different structure does not match this prefix.
+        assertTrue(HapiNames.parseAccessor("getPid3_PatientIdentifierList", "Gt1").isEmpty());
+    }
+
+    @Test
     void descriptionFallback() {
         assertEquals("patientIdentifierList", HapiNames.fromDescription("Patient Identifier List"));
         assertEquals("setIDPID", HapiNames.fromDescription("Set ID - PID"));

--- a/package/hl7/v2/java/pom.xml
+++ b/package/hl7/v2/java/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>com.zerobias</groupId>
             <artifactId>lite-filter</artifactId>
-            <version>1.0.0</version>
+            <version>1.0.4</version>
         </dependency>
 
         <!-- Testing -->
@@ -127,7 +127,7 @@
                                 <argument>compile</argument>
                                 <argument>exec:java</argument>
                                 <argument>-Dexec.mainClass=com.zerobias.module.hl7.codegen.SchemaGenerator</argument>
-                                <argument>-Dexec.args=v27 ${project.basedir}/src/main/resources</argument>
+                                <argument>-Dexec.args=v23,v231,v24,v25,v251,v26,v27 ${project.basedir}/src/main/resources ALL</argument>
                             </arguments>
                         </configuration>
                     </execution>

--- a/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/Hl7ApiServer.java
+++ b/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/Hl7ApiServer.java
@@ -12,6 +12,7 @@ import com.zerobias.module.hl7.ext.ExtensionLoader;
 import com.zerobias.module.hl7.health.HealthCheck;
 import com.zerobias.module.hl7.health.HealthSelfTest;
 import com.zerobias.module.hl7.materializer.Materializer;
+import com.zerobias.module.hl7.materializer.MaterializerRegistry;
 import com.zerobias.module.hl7.materializer.MessageMaterializer;
 import com.zerobias.module.hl7.materializer.StructureIndex;
 import com.zerobias.module.hl7.materializer.StructureResolver;
@@ -21,6 +22,7 @@ import com.zerobias.module.hl7.producer.Hl7ProducerFacade;
 import com.zerobias.module.hl7.producer.ObjectTree;
 import com.zerobias.module.hl7.producer.OperationRouter;
 import com.zerobias.module.hl7.producer.ProducerException;
+import com.zerobias.module.hl7.producer.Recaster;
 import com.zerobias.module.hl7.producer.SchemaRegistry;
 import io.javalin.Javalin;
 import org.slf4j.Logger;
@@ -132,16 +134,21 @@ public final class Hl7ApiServer {
             extensionScopes.put(d.structure(), d.whereClause());
         }
 
-        MessageMaterializer materializer = index != null
+        // The configured slot is the default (extension-merged); other versions seen
+        // on the wire (MSH-12) route to their own baked-in slot, lazily loaded, and
+        // unbundled versions degrade to the envelope schema (DESIGN §5 / §11.5).
+        MessageMaterializer defaultMaterializer = index != null
             ? new Materializer(index, resolver) : new EnvelopeMaterializer();
-        LOG.info("Materializer: {}; {} schemas, {} extension(s)", index != null
-            ? "structure-index " + versionSlot : "ENVELOPE fallback", schemas.size(), ext.loaded().size());
+        MaterializerRegistry materializers =
+            MaterializerRegistry.routing(versionSlot, defaultMaterializer, index != null);
+        LOG.info("Materializer: default slot {} ({}); per-message routing on MSH-12; {} schemas, {} extension(s)",
+            versionSlot, index != null ? "typed" : "ENVELOPE fallback", schemas.size(), ext.loaded().size());
 
         // One listener per declared port; each tags its messages with its name for
         // per-port provenance (DESIGN §11.4). All listeners feed the one shared buffer.
         for (ListenerSpec spec : config.listeners()) {
             Hl7ListenerService l = new Hl7ListenerService(spec.port(),
-                new BufferingApp(buffer, materializer, versionSlot, spec.name()));
+                new BufferingApp(buffer, materializers, spec.name()));
             l.start();
             listeners.add(l);
             LOG.info("MLLP listener '{}' up on {}", spec.name(), spec.port());
@@ -156,7 +163,11 @@ public final class Hl7ApiServer {
 
         // --- producer surface ---
         ObjectTree tree = new ObjectTree(buffer, schemas, versionSlot, extensionScopes);
-        this.facade = new Hl7ProducerFacade(buffer, tree, schemas);
+        // ops/recast re-materializes stored rows from raw ER7 under this same registry,
+        // routing each row by its own version, so a message first cast under a poorer
+        // schema can be upgraded in place once a better image ships.
+        Recaster recaster = new Recaster(materializers);
+        this.facade = new Hl7ProducerFacade(buffer, tree, schemas, recaster);
 
         Javalin app = Javalin.create(cfg -> {
             cfg.http.defaultContentType = "application/json";

--- a/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/buffer/BufferStore.java
+++ b/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/buffer/BufferStore.java
@@ -242,6 +242,48 @@ public final class BufferStore implements AutoCloseable {
         }
     }
 
+    /**
+     * Rows eligible for re-materialization ({@code ops/recast}, DESIGN §2.5): every
+     * row except {@code in_flight} (leased) ones, newest first, optionally narrowed
+     * by a pre-rendered WHERE fragment (null/blank = all). Leased rows are excluded
+     * so a recast never rewrites a message a consumer is mid-{@code take} on.
+     */
+    public synchronized List<BufferRow> recastable(String whereClause, int limit) throws SQLException {
+        StringBuilder sql = new StringBuilder("SELECT ").append(COLS)
+            .append(" FROM messages WHERE status <> 'in_flight'");
+        if (whereClause != null && !whereClause.isBlank()) {
+            sql.append(" AND (").append(whereClause).append(')');
+        }
+        sql.append(" ORDER BY received_at DESC, id DESC LIMIT ?");
+        try (PreparedStatement ps = conn.prepareStatement(sql.toString())) {
+            ps.setInt(1, limit);
+            try (ResultSet rs = ps.executeQuery()) {
+                List<BufferRow> out = new ArrayList<>();
+                while (rs.next()) {
+                    out.add(mapRow(rs));
+                }
+                return out;
+            }
+        }
+    }
+
+    /**
+     * Rewrite a row's materialized JSON + schema id ({@code ops/recast}). Guarded on
+     * {@code status <> 'in_flight'} so a row leased between {@link #recastable} and
+     * this update is not overwritten mid-flight (the select/update pair is not one
+     * transaction). Returns true iff a row was updated.
+     */
+    public synchronized boolean updateMapping(long id, String schemaId, String mappedJson)
+            throws SQLException {
+        try (PreparedStatement ps = conn.prepareStatement(
+                "UPDATE messages SET schema_id=?, mapped_json=? WHERE id=? AND status <> 'in_flight'")) {
+            ps.setString(1, schemaId);
+            ps.setString(2, mappedJson);
+            ps.setLong(3, id);
+            return ps.executeUpdate() > 0;
+        }
+    }
+
     /** Row count matching a pre-rendered WHERE clause (null/blank = all). */
     public synchronized long countWhere(String whereClause) throws SQLException {
         String sql = "SELECT count(*) FROM messages"
@@ -255,12 +297,25 @@ public final class BufferStore implements AutoCloseable {
      * is permitted — the name is interpolated, so it must never be caller-derived.
      */
     public synchronized List<String> distinctValues(String column) throws SQLException {
+        return distinctValues(column, null);
+    }
+
+    /**
+     * Distinct non-null values of a column within a pre-rendered scope (a WHERE
+     * fragment; null/blank = all rows). Drives the nested object tree — e.g. the
+     * versions present for one message structure ({@code /by-type/<MSG>/<v>}). The
+     * column is allow-listed (interpolated, never caller-derived); the scope is a
+     * caller-escaped fragment, same contract as {@link #countWhere}.
+     */
+    public synchronized List<String> distinctValues(String column, String whereClause) throws SQLException {
         if (!ALLOWED_DISTINCT_COLUMNS.contains(column)) {
             throw new IllegalArgumentException("distinctValues not allowed for column: " + column);
         }
+        String where = column + " IS NOT NULL"
+            + (whereClause != null && !whereClause.isBlank() ? " AND (" + whereClause + ")" : "");
         try (Statement st = conn.createStatement();
              ResultSet rs = st.executeQuery("SELECT DISTINCT " + column + " FROM messages WHERE "
-                 + column + " IS NOT NULL ORDER BY " + column)) {
+                 + where + " ORDER BY " + column)) {
             List<String> out = new ArrayList<>();
             while (rs.next()) {
                 out.add(rs.getString(1));
@@ -271,7 +326,7 @@ public final class BufferStore implements AutoCloseable {
 
     private static final java.util.Set<String> ALLOWED_DISTINCT_COLUMNS =
         java.util.Set.of("sending_app", "sending_facility", "message_structure", "message_code",
-            "source_port");
+            "source_port", "hl7_version");
 
     /** Delete acked rows acked longer ago than {@code olderThan} (ops/purge, DESIGN §2.5). */
     public synchronized int purge(Duration olderThan) throws SQLException {

--- a/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/filter/Hl7SqlAdapter.java
+++ b/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/filter/Hl7SqlAdapter.java
@@ -51,12 +51,26 @@ public class Hl7SqlAdapter implements Adapter {
     /** lite-filter adapter-registry key. */
     public static final String KEY = "SQL";
 
-    /** Top-level envelope properties that map to real columns (not JSON paths). */
-    private static final Map<String, String> ENVELOPE_COLUMNS = Map.of(
-        "controlId", "control_id",
-        "receivedAt", "received_at",
-        "status", "status",
-        "leaseId", "lease_id"
+    /**
+     * Top-level envelope + provenance properties that map to real (indexed-friendly,
+     * denormalized) columns instead of {@code json_extract} over {@code mapped_json}.
+     * These are the fast search axes — schema, version, port, sender, structure —
+     * so {@code (&(hl7Version=2.4)(sourcePort=...)(messageStructure=ADT_A01))} hits
+     * columns, not JSON paths.
+     */
+    private static final Map<String, String> ENVELOPE_COLUMNS = Map.ofEntries(
+        Map.entry("controlId", "control_id"),
+        Map.entry("receivedAt", "received_at"),
+        Map.entry("status", "status"),
+        Map.entry("leaseId", "lease_id"),
+        Map.entry("hl7Version", "hl7_version"),
+        Map.entry("sourcePort", "source_port"),
+        Map.entry("messageStructure", "message_structure"),
+        Map.entry("messageCode", "message_code"),
+        Map.entry("triggerEvent", "trigger_event"),
+        Map.entry("sendingApp", "sending_app"),
+        Map.entry("sendingFacility", "sending_facility"),
+        Map.entry("schemaId", "schema_id")
     );
 
     /** Columns stored as epoch-millis INTEGERs. */

--- a/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/listener/BufferingApp.java
+++ b/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/listener/BufferingApp.java
@@ -8,6 +8,7 @@ import ca.uhn.hl7v2.util.Terser;
 import com.zerobias.module.hl7.buffer.BufferRow;
 import com.zerobias.module.hl7.buffer.BufferStore;
 import com.zerobias.module.hl7.buffer.MessageStatus;
+import com.zerobias.module.hl7.materializer.MaterializerRegistry;
 import com.zerobias.module.hl7.materializer.MessageMaterializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,26 +37,27 @@ public final class BufferingApp implements ReceivingApplication<Message> {
     private static final Logger LOG = LoggerFactory.getLogger(BufferingApp.class);
 
     private final BufferStore buffer;
-    private final MessageMaterializer materializer;
-    private final String versionSlot;
+    private final MaterializerRegistry materializers;
     private final String sourcePort;
     private final Clock clock;
 
+    /** Fixed-slot (tests / config-pinned): every message uses {@code materializer} at {@code versionSlot}. */
     public BufferingApp(BufferStore buffer, MessageMaterializer materializer, String versionSlot) {
-        this(buffer, materializer, versionSlot, null, Clock.systemUTC());
+        this(buffer, MaterializerRegistry.pinned(versionSlot, materializer), null, Clock.systemUTC());
     }
 
-    /** One {@code BufferingApp} per MLLP listener; {@code sourcePort} is that listener's name. */
-    public BufferingApp(BufferStore buffer, MessageMaterializer materializer, String versionSlot,
-            String sourcePort) {
-        this(buffer, materializer, versionSlot, sourcePort, Clock.systemUTC());
+    /**
+     * Per-message routing: {@code materializers} selects the materializer + collection
+     * schema by each message's MSH-12. One {@code BufferingApp} per MLLP listener;
+     * {@code sourcePort} is that listener's name.
+     */
+    public BufferingApp(BufferStore buffer, MaterializerRegistry materializers, String sourcePort) {
+        this(buffer, materializers, sourcePort, Clock.systemUTC());
     }
 
-    public BufferingApp(BufferStore buffer, MessageMaterializer materializer, String versionSlot,
-            String sourcePort, Clock clock) {
+    public BufferingApp(BufferStore buffer, MaterializerRegistry materializers, String sourcePort, Clock clock) {
         this.buffer = buffer;
-        this.materializer = materializer;
-        this.versionSlot = versionSlot;
+        this.materializers = materializers;
         this.sourcePort = sourcePort;
         this.clock = clock;
     }
@@ -77,6 +79,12 @@ public final class BufferingApp implements ReceivingApplication<Message> {
                 structure = code + "_" + trigger; // e.g. ADT_A01 when MSH-9-3 omitted
             }
 
+            // Route by the message's own declared version (MSH-12), not a fixed config
+            // slot: a mixed-version feed materializes + labels each message correctly,
+            // and an unbundled version degrades to generic + the envelope schema.
+            final String version = t.get("/MSH-12");
+            final MessageMaterializer materializer = materializers.materializerFor(version);
+
             final BufferRow row = new BufferRow(
                 0,
                 Instant.now(clock),
@@ -86,8 +94,8 @@ public final class BufferingApp implements ReceivingApplication<Message> {
                 trigger,
                 t.get("/MSH-3"),
                 t.get("/MSH-4"),
-                t.get("/MSH-12"),
-                "schema:table:hl7v2." + versionSlot + "." + structure,
+                version,
+                materializers.schemaIdFor(version, structure),
                 in.encode().getBytes(StandardCharsets.UTF_8),
                 materializer.toTypedJson(in),
                 MessageStatus.NEW,

--- a/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/materializer/MaterializerRegistry.java
+++ b/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/materializer/MaterializerRegistry.java
@@ -1,0 +1,89 @@
+package com.zerobias.module.hl7.materializer;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Chooses the materializer and collection schema id for each inbound message by
+ * its declared HL7 version (MSH-12), so one listener can serve an emergent,
+ * mixed-version feed (DESIGN §5 / §11.5).
+ *
+ * <p>A version maps to a slot the same way everywhere: {@code "2.4" -> "v24"},
+ * {@code "2.5.1" -> "v251"}. Each slot's {@link StructureIndex} is loaded from the
+ * classpath on first use and cached; a version whose slot isn't baked into the
+ * image degrades to generic {@link EnvelopeMaterializer} + the shared message
+ * envelope schema — the message is still buffered, labelled with its true version,
+ * and searchable. Never drops on an unseen version.
+ *
+ * <p>Extensions (DESIGN §7) apply to the configured default slot only; other slots
+ * load plain. A {@code pinned} registry (config-fixed deployments / tests) ignores
+ * MSH-12 and routes everything through one materializer.
+ */
+public final class MaterializerRegistry {
+
+    /** Heterogeneous / unbundled fallback schema (DESIGN §2.2). */
+    public static final String ENVELOPE_SCHEMA = "schema:shared:hl7v2.message-envelope";
+
+    private final String defaultSlot;
+    private final boolean routeByVersion;
+    private final MessageMaterializer generic = new EnvelopeMaterializer();
+    private final Map<String, Entry> cache = new ConcurrentHashMap<>();
+
+    private record Entry(MessageMaterializer materializer, boolean typed) {
+    }
+
+    private MaterializerRegistry(String defaultSlot, MessageMaterializer defaultMaterializer,
+            boolean defaultTyped, boolean routeByVersion) {
+        this.defaultSlot = defaultSlot;
+        this.routeByVersion = routeByVersion;
+        cache.put(defaultSlot, new Entry(defaultMaterializer, defaultTyped));
+    }
+
+    /**
+     * Per-message routing: the configured slot uses {@code defaultMaterializer}
+     * (extension-merged); any other version's slot is loaded lazily from the classpath.
+     */
+    public static MaterializerRegistry routing(String defaultSlot,
+            MessageMaterializer defaultMaterializer, boolean defaultTyped) {
+        return new MaterializerRegistry(defaultSlot, defaultMaterializer, defaultTyped, true);
+    }
+
+    /** Fixed-slot registry: every message uses one materializer, MSH-12 ignored. */
+    public static MaterializerRegistry pinned(String slot, MessageMaterializer materializer) {
+        return new MaterializerRegistry(slot, materializer, materializer instanceof Materializer, false);
+    }
+
+    /** HAPI structure slot for an MSH-12 version string ({@code "2.4" -> "v24"}). */
+    public String slotFor(String hl7Version) {
+        if (!routeByVersion || hl7Version == null || hl7Version.isBlank()) {
+            return defaultSlot;
+        }
+        return "v" + hl7Version.replace(".", "");
+    }
+
+    /** The materializer for a message of the given HL7 version (generic if the slot isn't bundled). */
+    public MessageMaterializer materializerFor(String hl7Version) {
+        return entryFor(hl7Version).materializer();
+    }
+
+    /**
+     * The collection schema id for {@code structure} at the message's version: the
+     * version-scoped table schema when the slot is bundled, else the shared envelope
+     * (so unbundled-version rows still resolve to a real schema).
+     */
+    public String schemaIdFor(String hl7Version, String structure) {
+        Entry e = entryFor(hl7Version);
+        return e.typed()
+            ? "schema:table:hl7v2." + slotFor(hl7Version) + "." + structure
+            : ENVELOPE_SCHEMA;
+    }
+
+    private Entry entryFor(String hl7Version) {
+        return cache.computeIfAbsent(slotFor(hl7Version), this::load);
+    }
+
+    private Entry load(String slot) {
+        StructureIndex index = StructureIndex.fromClasspath(slot);
+        return index == null ? new Entry(generic, false) : new Entry(new Materializer(index), true);
+    }
+}

--- a/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/producer/Hl7Operations.java
+++ b/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/producer/Hl7Operations.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 
 /**
@@ -29,6 +30,11 @@ import java.util.function.Function;
  *   <li>{@code release} — return a lease early without consuming.</li>
  *   <li>{@code replay} — force in_flight rows back to {@code new} (consumer
  *       recovery), optionally filtered.</li>
+ *   <li>{@code recast} — re-materialize rows from their raw ER7 under the current
+ *       schema, rewriting {@code mapped_json}/{@code schema_id} only where it
+ *       improved (upgrade after a better schema/extension ships); skips in_flight
+ *       rows, optionally filtered; returns {@code examined}/{@code recast}/
+ *       {@code unchanged}/{@code failed} counts.</li>
  *   <li>{@code purge} — delete acked rows older than a duration.</li>
  * </ul>
  *
@@ -48,10 +54,18 @@ public final class Hl7Operations {
 
     private final BufferStore buffer;
     private final Function<BufferRow, Map<String, Object>> elementMapper;
+    /** Re-materializes rows from raw ER7 for {@code recast}; null when unconfigured (back-compat). */
+    private final Recaster recaster;
 
     public Hl7Operations(BufferStore buffer, Function<BufferRow, Map<String, Object>> elementMapper) {
+        this(buffer, elementMapper, null);
+    }
+
+    public Hl7Operations(BufferStore buffer, Function<BufferRow, Map<String, Object>> elementMapper,
+            Recaster recaster) {
         this.buffer = buffer;
         this.elementMapper = elementMapper;
+        this.recaster = recaster;
     }
 
     /** Dispatch a {@code /hl7-v2-receiver/ops/<fn>} invocation. */
@@ -65,6 +79,8 @@ public final class Hl7Operations {
                 return release(input);
             case "replay":
                 return replay(input);
+            case "recast":
+                return recast(input);
             case "purge":
                 return purge(input);
             default:
@@ -104,6 +120,47 @@ public final class Hl7Operations {
     private Map<String, Object> replay(Map<String, Object> input) throws SQLException {
         int replayed = buffer.replay(renderFilter(strArg(input, "filter")));
         return Map.of("replayed", replayed);
+    }
+
+    /**
+     * Re-materialize stored messages from their raw ER7 under the currently-loaded
+     * schema, rewriting {@code mapped_json}/{@code schema_id} only where the result
+     * actually improved (the "when a better schema is available" contract). Leased
+     * ({@code in_flight}) rows are excluded. Per-row failures (an un-parseable raw)
+     * are counted, never fatal. Processes at most {@code max} rows (newest first) per
+     * call; re-invoke to continue a large backlog.
+     */
+    private Map<String, Object> recast(Map<String, Object> input) throws SQLException {
+        if (recaster == null) {
+            throw ProducerException.unsupported("recast is unavailable: no materializer configured");
+        }
+        int max = clampMax(intArg(input, "max", MAX_CAP));
+        String where = renderFilter(strArg(input, "filter"));
+
+        List<BufferRow> rows = buffer.recastable(where, max);
+        int recast = 0;
+        int unchanged = 0;
+        int failed = 0;
+        for (BufferRow row : rows) {
+            try {
+                Optional<Recaster.Mapping> m = recaster.recast(row);
+                if (m.isPresent() && buffer.updateMapping(row.id(), m.get().schemaId(), m.get().mappedJson())) {
+                    recast++;
+                } else {
+                    // empty = reproduced the stored value; update==false = row got leased
+                    // between select and write (skipped). Either way, nothing rewritten.
+                    unchanged++;
+                }
+            } catch (Exception e) {
+                failed++;
+            }
+        }
+        Map<String, Object> out = new LinkedHashMap<>();
+        out.put("examined", rows.size());
+        out.put("recast", recast);
+        out.put("unchanged", unchanged);
+        out.put("failed", failed);
+        return out;
     }
 
     private Map<String, Object> purge(Map<String, Object> input) throws SQLException {

--- a/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/producer/Hl7ProducerFacade.java
+++ b/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/producer/Hl7ProducerFacade.java
@@ -37,10 +37,15 @@ public final class Hl7ProducerFacade {
     private final Hl7Operations ops;
 
     public Hl7ProducerFacade(BufferStore buffer, ObjectTree tree, SchemaRegistry schemas) {
+        this(buffer, tree, schemas, null);
+    }
+
+    public Hl7ProducerFacade(BufferStore buffer, ObjectTree tree, SchemaRegistry schemas,
+            Recaster recaster) {
         this.buffer = buffer;
         this.tree = tree;
         this.schemas = schemas;
-        this.ops = new Hl7Operations(buffer, this::toElement);
+        this.ops = new Hl7Operations(buffer, this::toElement, recaster);
         Hl7Filter.register();
     }
 
@@ -124,7 +129,7 @@ public final class Hl7ProducerFacade {
         throw ProducerException.unsupported("Collection is read-only; use ops/purge to evict acked rows");
     }
 
-    // --- Functions: ops/take|ack|release|replay|purge (DESIGN §2.5) -------
+    // --- Functions: ops/take|ack|release|replay|recast|purge (DESIGN §2.5) -------
 
     public String invokeFunction(String objectId, String inputJson) throws SQLException {
         requireId(objectId);

--- a/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/producer/ObjectTree.java
+++ b/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/producer/ObjectTree.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeSet;
 
 /**
  * The DataProducer object hierarchy (DESIGN §2.1): a tree of container /
@@ -17,19 +18,32 @@ import java.util.Map;
  * └─ /hl7-v2-receiver            container
  *    ├─ /messages                collection (all rows, message-envelope schema)
  *    ├─ /by-type                 container
- *    │  └─ /by-type/&lt;MSG&gt;        collection (one per configured structure)
+ *    │  └─ /by-type/&lt;type&gt;       collection while a type has ONE version (already
+ *    │     └─ /by-type/&lt;type&gt;/&lt;v&gt; homogeneous); ELSE a container whose per-version
+ *    │                             leaves are the collections — the version level is
+ *    │                             interposed only when a type spans versions
+ *    ├─ /by-version              container
+ *    │  └─ /by-version/&lt;v&gt;       collection (one per distinct HL7 version, envelope)
  *    ├─ /by-sender               container
  *    │  └─ /by-sender/&lt;APP&gt;       collection (one per distinct MSH-3)
  *    ├─ /by-port                 container
  *    │  └─ /by-port/&lt;NAME&gt;        collection (one per distinct listener port name)
  *    ├─ /stats                   document
  *    └─ /ops                     container
- *       └─ /ops/&lt;fn&gt;             function (take/ack/release/replay/purge)
+ *       └─ /ops/&lt;fn&gt;             function (take/ack/release/replay/recast/purge)
  * </pre>
  *
- * This class owns node metadata and classification; the buffer-backed element
- * reads live in {@link Hl7ProducerFacade}. Collection sizes and the dynamic
- * {@code /by-sender/<app>} children are read live from the buffer.
+ * <p>An individual HL7 <em>message is an atom</em> — a collection <em>element</em>
+ * (fetched by control-id), never a node in this tree. The only folders are the
+ * discriminators, and their children are <em>emergent</em> — read live from the
+ * buffer's distinct values, so a node appears the first time a matching message
+ * lands. A collection must be <b>homogeneous</b> (one schema), and a discriminator
+ * level is interposed only when required to reach that: {@code /by-type/<type>} is
+ * itself the collection while a type has a single version, and splits into
+ * {@code /by-type/<type>/<v>} only once it spans versions. Coarser facets
+ * ({@code /by-version}, {@code /by-sender}, {@code /by-port}) are heterogeneous
+ * (envelope schema). Extension structures (DESIGN §7) surface as discriminator-scoped
+ * {@code /by-type/<X>} collections alongside the base ones.
  */
 public final class ObjectTree {
 
@@ -37,20 +51,24 @@ public final class ObjectTree {
     static final String RECEIVER = "/hl7-v2-receiver";
     static final String MESSAGES = RECEIVER + "/messages";
     static final String BY_TYPE = RECEIVER + "/by-type";
+    static final String BY_VERSION = RECEIVER + "/by-version";
     static final String BY_SENDER = RECEIVER + "/by-sender";
     static final String BY_PORT = RECEIVER + "/by-port";
     static final String STATS = RECEIVER + "/stats";
     static final String OPS = RECEIVER + "/ops";
 
     static final String ENVELOPE_SCHEMA = "schema:shared:hl7v2.message-envelope";
-    static final List<String> OPS_FUNCTIONS = List.of("take", "ack", "release", "replay", "purge");
+    static final List<String> OPS_FUNCTIONS =
+        List.of("take", "ack", "release", "replay", "recast", "purge");
 
     private final BufferStore buffer;
     private final SchemaRegistry schemas;
-    private final String version;
     /** Extension structures → buffer scope (discriminator WHERE clause), DESIGN §7.2. */
     private final Map<String, String> extensionScopes;
 
+    /** {@code version} (the configured default slot) is retained in the signature for
+     *  callers but no longer used: a collection's schema is now derived per row from
+     *  the message's own HL7 version ({@code /by-type/<MSG>/<v>}). */
     public ObjectTree(BufferStore buffer, SchemaRegistry schemas, String version) {
         this(buffer, schemas, version, Map.of());
     }
@@ -59,7 +77,6 @@ public final class ObjectTree {
             Map<String, String> extensionScopes) {
         this.buffer = buffer;
         this.schemas = schemas;
-        this.version = version;
         this.extensionScopes = extensionScopes;
     }
 
@@ -67,33 +84,85 @@ public final class ObjectTree {
     public record Collection(String id, String scopeWhere, String schemaId) {
     }
 
-    /** by-type structures (all namespaces) → collection schema id. */
-    private Map<String, String> byTypeStructures() {
-        return schemas.messageStructureIds();
+    // --- version / structure helpers ---------------------------------------
+
+    /** HAPI structure slot for an HL7 version string ({@code "2.4" -> "v24"}). */
+    private static String slot(String hl7Version) {
+        return "v" + hl7Version.replace(".", "");
     }
 
-    /** The buffer scope for a by-type structure: discriminator WHERE for extensions, else message_structure. */
-    private String byTypeScope(String struct) {
-        String ext = extensionScopes.get(struct);
-        return ext != null ? ext : "message_structure = " + sql(struct);
+    private boolean isExtensionStructure(String struct) {
+        return extensionScopes.containsKey(struct);
     }
+
+    /** Base (non-extension) message structures actually present in the buffer. */
+    private List<String> baseStructures() throws SQLException {
+        return buffer.distinctValues("message_structure");
+    }
+
+    /** HL7 versions present for one base structure (the {@code /by-type/<MSG>} children). */
+    private List<String> versionsForStructure(String struct) throws SQLException {
+        return buffer.distinctValues("hl7_version", "message_structure = " + sql(struct));
+    }
+
+    private String baseTypeScope(String struct, String ver) {
+        return "message_structure = " + sql(struct) + " AND hl7_version = " + sql(ver);
+    }
+
+    /** Version-correct table schema for a structure, or the envelope if that slot isn't bundled. */
+    private String tableSchema(String struct, String ver) {
+        String tableId = "schema:table:hl7v2." + slot(ver) + "." + struct;
+        return schemas.has(tableId) ? tableId : ENVELOPE_SCHEMA;
+    }
+
+    /** Extension collection schema id (namespace-scoped table), from the merged catalog. */
+    private String extensionSchema(String struct) {
+        String id = schemas.messageStructureIds().get(struct);
+        return id != null ? id : ENVELOPE_SCHEMA;
+    }
+
+    // --- collection resolution ---------------------------------------------
 
     /**
      * Resolve a collection id to its buffer scope, or throw: {@code noSuchObjectError}
-     * if a {@code /by-type|/by-sender} discriminator value is unknown,
-     * {@code UnsupportedOperationError} if the id isn't a collection at all.
+     * for an unknown discriminator value, {@code UnsupportedOperationError} if the id
+     * is a container (e.g. a bare {@code /by-type/<MSG>}) rather than a collection.
      */
     public Collection resolveCollection(String id) throws SQLException {
         if (MESSAGES.equals(id)) {
             return new Collection(id, null, ENVELOPE_SCHEMA);
         }
         if (id.startsWith(BY_TYPE + "/")) {
-            String struct = id.substring((BY_TYPE + "/").length());
-            String schemaId = byTypeStructures().get(struct);
-            if (schemaId == null) {
+            String rem = id.substring((BY_TYPE + "/").length());
+            int slash = rem.indexOf('/');
+            if (slash < 0) {
+                if (isExtensionStructure(rem)) {
+                    return new Collection(id, extensionScopes.get(rem), extensionSchema(rem));
+                }
+                List<String> vers = versionsForStructure(rem);
+                if (vers.isEmpty()) {
+                    throw ProducerException.noSuchObject(id);
+                }
+                if (vers.size() == 1) {
+                    // homogeneous by type alone — no version discriminator needed
+                    return new Collection(id, "message_structure = " + sql(rem), tableSchema(rem, vers.get(0)));
+                }
+                throw ProducerException.unsupported("Object is not a collection (drill into a version): " + id);
+            }
+            String struct = rem.substring(0, slash);
+            String ver = rem.substring(slash + 1);
+            List<String> vers = versionsForStructure(struct);
+            if (!vers.contains(ver) || vers.size() == 1) {   // version node exists only when required
                 throw ProducerException.noSuchObject(id);
             }
-            return new Collection(id, byTypeScope(struct), schemaId);
+            return new Collection(id, baseTypeScope(struct, ver), tableSchema(struct, ver));
+        }
+        if (id.startsWith(BY_VERSION + "/")) {
+            String ver = id.substring((BY_VERSION + "/").length());
+            if (!buffer.distinctValues("hl7_version").contains(ver)) {
+                throw ProducerException.noSuchObject(id);
+            }
+            return new Collection(id, "hl7_version = " + sql(ver), ENVELOPE_SCHEMA);
         }
         if (id.startsWith(BY_SENDER + "/")) {
             String app = id.substring((BY_SENDER + "/").length());
@@ -109,10 +178,11 @@ public final class ObjectTree {
             }
             return new Collection(id, "source_port = " + sql(port), ENVELOPE_SCHEMA);
         }
-        // exists but isn't a collection, or doesn't exist
         object(id); // throws noSuchObject if unknown
         throw ProducerException.unsupported("Object is not a collection: " + id);
     }
+
+    // --- object metadata ----------------------------------------------------
 
     /** Object metadata for {@code id}, or throw {@code noSuchObjectError}. */
     public Map<String, Object> object(String id) throws SQLException {
@@ -125,6 +195,8 @@ public final class ObjectTree {
                 return collection(MESSAGES, "messages", ENVELOPE_SCHEMA, buffer.count());
             case BY_TYPE:
                 return container(BY_TYPE, "by-type");
+            case BY_VERSION:
+                return container(BY_VERSION, "by-version");
             case BY_SENDER:
                 return container(BY_SENDER, "by-sender");
             case BY_PORT:
@@ -140,13 +212,39 @@ public final class ObjectTree {
 
     private Map<String, Object> dynamicObject(String id) throws SQLException {
         if (id.startsWith(BY_TYPE + "/")) {
-            String struct = id.substring((BY_TYPE + "/").length());
-            String schemaId = byTypeStructures().get(struct);
-            if (schemaId == null) {
+            String rem = id.substring((BY_TYPE + "/").length());
+            int slash = rem.indexOf('/');
+            if (slash < 0) {
+                if (isExtensionStructure(rem)) {
+                    long size = buffer.countWhere(extensionScopes.get(rem));
+                    return collection(id, rem, extensionSchema(rem), size);
+                }
+                List<String> vers = versionsForStructure(rem);
+                if (vers.isEmpty()) {
+                    throw ProducerException.noSuchObject(id);
+                }
+                if (vers.size() == 1) {
+                    long size = buffer.countWhere("message_structure = " + sql(rem));
+                    return collection(id, rem, tableSchema(rem, vers.get(0)), size);   // homogeneous: single version
+                }
+                return container(id, rem);   // spans versions: drill in
+            }
+            String struct = rem.substring(0, slash);
+            String ver = rem.substring(slash + 1);
+            List<String> vers = versionsForStructure(struct);
+            if (!vers.contains(ver) || vers.size() == 1) {
                 throw ProducerException.noSuchObject(id);
             }
-            long size = buffer.countWhere(byTypeScope(struct));
-            return collection(id, struct, schemaId, size);
+            long size = buffer.countWhere(baseTypeScope(struct, ver));
+            return collection(id, ver, tableSchema(struct, ver), size);
+        }
+        if (id.startsWith(BY_VERSION + "/")) {
+            String ver = id.substring((BY_VERSION + "/").length());
+            if (!buffer.distinctValues("hl7_version").contains(ver)) {
+                throw ProducerException.noSuchObject(id);
+            }
+            long size = buffer.countWhere("hl7_version = " + sql(ver));
+            return collection(id, ver, ENVELOPE_SCHEMA, size);
         }
         if (id.startsWith(BY_SENDER + "/")) {
             String app = id.substring((BY_SENDER + "/").length());
@@ -174,6 +272,8 @@ public final class ObjectTree {
         throw ProducerException.noSuchObject(id);
     }
 
+    // --- children -----------------------------------------------------------
+
     /** Direct children of {@code id}, or throw {@code noSuchObjectError}. */
     public List<Map<String, Object>> children(String id) throws SQLException {
         List<Map<String, Object>> out = new ArrayList<>();
@@ -184,17 +284,22 @@ public final class ObjectTree {
             case RECEIVER:
                 out.add(object(MESSAGES));
                 out.add(object(BY_TYPE));
+                out.add(object(BY_VERSION));
                 out.add(object(BY_SENDER));
                 out.add(object(BY_PORT));
                 out.add(object(STATS));
                 out.add(object(OPS));
                 return out;
             case BY_TYPE:
-                // Sort for a stable listing — the registry's structure map has no
-                // guaranteed iteration order (it varies by classpath/platform), and
-                // by-sender (SQL ORDER BY) / ops (fixed list) are already deterministic.
-                for (String struct : new java.util.TreeSet<>(byTypeStructures().keySet())) {
+                // Received base structures + extension structures, sorted for a stable
+                // listing (distinct-value order is platform-dependent).
+                for (String struct : byTypeChildren()) {
                     out.add(object(BY_TYPE + "/" + struct));
+                }
+                return out;
+            case BY_VERSION:
+                for (String ver : buffer.distinctValues("hl7_version")) {
+                    out.add(object(BY_VERSION + "/" + ver));
                 }
                 return out;
             case BY_SENDER:
@@ -213,15 +318,36 @@ public final class ObjectTree {
                 }
                 return out;
             default:
-                // leaf (collection/document/function) -> no children; unknown -> 404
-                Map<String, Object> obj = object(id);
-                @SuppressWarnings("unchecked")
-                List<String> classes = (List<String>) obj.get("objectClass");
-                if (classes.contains("container")) {
-                    return out; // a container with no static children
-                }
-                return out;
+                return dynamicChildren(id);
         }
+    }
+
+    /** Children of a dynamic container — a multi-version {@code /by-type/<type>} lists its versions. */
+    private List<Map<String, Object>> dynamicChildren(String id) throws SQLException {
+        List<Map<String, Object>> out = new ArrayList<>();
+        if (id.startsWith(BY_TYPE + "/")) {
+            String rem = id.substring((BY_TYPE + "/").length());
+            if (rem.indexOf('/') < 0 && !isExtensionStructure(rem)) {
+                List<String> vers = versionsForStructure(rem);
+                if (vers.size() > 1) {   // only a multi-version type is a container
+                    for (String ver : vers) {
+                        out.add(object(BY_TYPE + "/" + rem + "/" + ver));
+                    }
+                    return out;
+                }
+            }
+        }
+        // leaf (collection/document/function) or an empty container -> no children;
+        // unknown id -> 404 via object().
+        object(id);
+        return out;
+    }
+
+    /** Sorted union of received base structures and merged extension structures. */
+    private List<String> byTypeChildren() throws SQLException {
+        TreeSet<String> names = new TreeSet<>(baseStructures());
+        names.addAll(extensionScopes.keySet());
+        return new ArrayList<>(names);
     }
 
     // --- object builders ---------------------------------------------------

--- a/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/producer/Recaster.java
+++ b/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/producer/Recaster.java
@@ -1,0 +1,74 @@
+package com.zerobias.module.hl7.producer;
+
+import ca.uhn.hl7v2.DefaultHapiContext;
+import ca.uhn.hl7v2.HL7Exception;
+import ca.uhn.hl7v2.HapiContext;
+import ca.uhn.hl7v2.model.Message;
+import ca.uhn.hl7v2.parser.GenericModelClassFactory;
+import ca.uhn.hl7v2.parser.PipeParser;
+import ca.uhn.hl7v2.validation.impl.ValidationContextFactory;
+import com.zerobias.module.hl7.buffer.BufferRow;
+import com.zerobias.module.hl7.materializer.MaterializerRegistry;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+/**
+ * Re-derives a stored message's typed JSON from its retained raw ER7 using the
+ * <em>current</em> {@link MaterializerRegistry} (DESIGN §5). This is what lets
+ * {@code ops/recast} upgrade rows that were first cast under a poorer schema — the
+ * envelope fallback, an unknown structure, or before a version slot / extension pack
+ * was bundled — once a better schema ships in a new image.
+ *
+ * <p>Routing is per-row by the message's own stored HL7 version (MSH-12), exactly as
+ * the receive path routes at ingest, so recast re-materializes each row against the
+ * best schema now bundled <em>for that version</em> and re-labels its schema id the
+ * same way {@code BufferingApp} does — including the envelope-fallback id when the
+ * row's version still isn't bundled.
+ *
+ * <p>Re-parsing mirrors ingest: generic parsing (no typed HAPI structure jars,
+ * DESIGN §4.1) with validation disabled, so the canonical {@code raw_er7} round-trips
+ * to the {@link Message} the materializer expects.
+ */
+public final class Recaster {
+
+    /** The recomputed persisted fields for a row. */
+    public record Mapping(String schemaId, String mappedJson) {
+    }
+
+    private final MaterializerRegistry materializers;
+    private final PipeParser parser;
+
+    public Recaster(MaterializerRegistry materializers) {
+        this.materializers = materializers;
+        // A parser-only context (never a server), so it is immune to the shared-executor
+        // shutdown footgun that forces Hl7ListenerService to own a dedicated executor —
+        // PipeParser.parse is synchronous and never touches the executor service.
+        HapiContext ctx = new DefaultHapiContext();
+        ctx.setValidationContext(ValidationContextFactory.noValidation());
+        ctx.setModelClassFactory(new GenericModelClassFactory());
+        this.parser = ctx.getPipeParser();
+    }
+
+    /**
+     * Re-materialize {@code row} from its raw ER7 under the current registry, routing
+     * by the row's stored HL7 version. Returns the new mapping when it differs from
+     * what is stored, or empty when re-materialization reproduces the stored value
+     * (nothing to upgrade — the "only if improved" contract). Throws when the raw
+     * can't be parsed/materialized.
+     *
+     * <p>{@code synchronized}: a single {@link PipeParser} is reused across calls, and
+     * HAPI parsers are not guaranteed thread-safe, so concurrent recast invocations
+     * serialize here (an admin op, not a hot path).
+     */
+    public synchronized Optional<Mapping> recast(BufferRow row) throws HL7Exception {
+        Message message = parser.parse(new String(row.rawEr7(), StandardCharsets.UTF_8));
+        String version = row.hl7Version();
+        String schemaId = materializers.schemaIdFor(version, row.messageStructure());
+        String mappedJson = materializers.materializerFor(version).toTypedJson(message);
+        if (mappedJson.equals(row.mappedJson()) && schemaId.equals(row.schemaId())) {
+            return Optional.empty();
+        }
+        return Optional.of(new Mapping(schemaId, mappedJson));
+    }
+}

--- a/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/producer/SchemaRegistry.java
+++ b/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/producer/SchemaRegistry.java
@@ -17,6 +17,7 @@ import java.util.Enumeration;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.stream.Stream;
@@ -26,26 +27,32 @@ import java.util.stream.Stream;
  * {@code getSchema} operation and to enumerate the {@code /by-type/<X>}
  * collections in the object tree.
  *
- * <p>The schema tree is produced at build time (Phase 1 codegen, a build
- * artifact) under {@code schemas/<version>/{messages,groups,segments,datatypes,
- * tables}/*.json} + {@code schemas/shared/message-envelope.json}. Rather than
- * decode ids back into file paths, the registry walks the tree once at startup,
- * parses each file's {@code id}, and indexes id → raw JSON. The
- * {@code structure-index/*.json} files (no schema {@code id}) are skipped.
+ * <p><b>Lazy by id → resource.</b> The general-purpose catalog is large (all
+ * message families across every supported version → thousands of small files).
+ * Rather than parse every file into memory at boot, the registry indexes only the
+ * schema <em>ids</em> — reconstructed from each file's <em>path</em>
+ * ({@code schemas/<version>/{messages,groups,segments,datatypes,tables}/<name>.json}
+ * → {@code schema:{table|type|enum}:hl7v2.<version>.<name>}) with no content read —
+ * and reads a schema's JSON on demand in {@link #getSchema}. Shared schemas
+ * ({@code schemas/shared/*.json}, a handful) carry an id the path can't
+ * reconstruct, so those are read once at index time to capture it.
+ *
+ * <p>{@code structure-index/*.json} (no schema id, different tree) is never scanned.
  */
 public final class SchemaRegistry {
 
     private static final Gson GSON = new Gson();
 
-    /** schemaId → raw JSON text (served verbatim). */
-    private final Map<String, String> byId = new LinkedHashMap<>();
+    /** schemaId → a loader that yields the raw JSON (classpath resource, file, or in-memory extension). */
+    private final Map<String, Supplier<String>> loaders = new LinkedHashMap<>();
 
     private SchemaRegistry() {
     }
 
     /**
-     * Build a registry by scanning {@code schemaRoot} (the codegen output dir
-     * containing {@code schemas/}). Returns an empty registry if the dir is absent.
+     * Build a registry by scanning {@code schemaRoot} (a dir containing
+     * {@code schemas/}). Ids are reconstructed from paths; content is read lazily.
+     * Returns an empty registry if the dir is absent.
      */
     public static SchemaRegistry fromDirectory(Path schemaRoot) {
         SchemaRegistry r = new SchemaRegistry();
@@ -55,7 +62,7 @@ public final class SchemaRegistry {
         }
         try (Stream<Path> walk = Files.walk(schemas)) {
             walk.filter(p -> p.toString().endsWith(".json"))
-                .forEach(r::index);
+                .forEach(p -> r.indexFile(schemaRoot, p));
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to scan schema tree at " + schemas, e);
         }
@@ -64,10 +71,9 @@ public final class SchemaRegistry {
 
     /**
      * Build a registry from the {@code /schemas} resources on the classpath — how
-     * the packaged module serves them: the codegen bakes the tree into the jar at
-     * build time (Phase 1 decision), so production reads it from the classpath, not
-     * a filesystem dir. Handles both the shaded jar ({@code jar:} URL) and an
-     * exploded {@code target/classes} ({@code file:} URL). Empty if absent.
+     * the packaged module serves them. Handles both the shaded jar ({@code jar:}
+     * URL) and an exploded {@code target/classes} ({@code file:} URL); either way a
+     * schema is read from the classpath on demand. Empty if absent.
      */
     public static SchemaRegistry fromClasspath() {
         SchemaRegistry r = new SchemaRegistry();
@@ -85,15 +91,15 @@ public final class SchemaRegistry {
                         JarEntry e = entries.nextElement();
                         if (!e.isDirectory()
                                 && e.getName().startsWith("schemas/") && e.getName().endsWith(".json")) {
-                            try (InputStream in = jar.getInputStream(e)) {
-                                r.indexJson(new String(in.readAllBytes(), StandardCharsets.UTF_8));
-                            }
+                            r.indexClasspath(e.getName());
                         }
                     }
                 }
             } else if ("file".equals(root.getProtocol())) {
+                Path classpathRoot = Path.of(root.toURI()).getParent();   // parent of /schemas
                 try (Stream<Path> walk = Files.walk(Path.of(root.toURI()))) {
-                    walk.filter(p -> p.toString().endsWith(".json")).forEach(r::index);
+                    walk.filter(p -> p.toString().endsWith(".json"))
+                        .forEach(p -> r.indexClasspath(classpathRoot.relativize(p).toString().replace('\\', '/')));
                 }
             }
         } catch (IOException | URISyntaxException e) {
@@ -102,30 +108,103 @@ public final class SchemaRegistry {
         return r;
     }
 
-    private void index(Path file) {
-        try {
-            indexJson(Files.readString(file));
-        } catch (IOException e) {
-            throw new UncheckedIOException("Failed to read schema " + file, e);
+    // --- indexing (id from path; content deferred) -------------------------
+
+    /** Index one classpath resource ({@code schemas/...json}) by its reconstructed/read id. */
+    private void indexClasspath(String resource) {
+        String[] parts = resource.split("/");
+        String id = idFromPath(parts, () -> readIdFromStream(SchemaRegistry.class.getResourceAsStream("/" + resource)));
+        if (id != null) {
+            loaders.put(id, () -> readClasspath(resource));
         }
     }
 
-    /** Parse one schema JSON and index it by its {@code schema:} id (no-op otherwise). */
-    private void indexJson(String json) {
+    /** Index one filesystem schema file by its reconstructed/read id. */
+    private void indexFile(Path schemaRoot, Path file) {
+        String[] parts = schemaRoot.relativize(file).toString().replace('\\', '/').split("/");
+        String id = idFromPath(parts, () -> readIdFromString(readFile(file)));
+        if (id != null) {
+            loaders.put(id, () -> readFile(file));
+        }
+    }
+
+    /**
+     * The schema id for a {@code schemas/...} path. Version-scoped files
+     * ({@code schemas/<v>/<subdir>/<name>.json}) reconstruct without a read; shared
+     * files ({@code schemas/shared/<name>.json}) fall back to {@code sharedId} which
+     * reads the file's declared id. Returns null for anything else.
+     */
+    private static String idFromPath(String[] parts, Supplier<String> sharedId) {
+        if (parts.length == 4 && "schemas".equals(parts[0])) {
+            String version = parts[1];
+            String name = stripJson(parts[3]);
+            switch (parts[2]) {
+                case "messages":  return "schema:table:hl7v2." + version + "." + name;
+                case "segments":
+                case "groups":
+                case "datatypes": return "schema:type:hl7v2." + version + "." + name;
+                case "tables":    return "schema:enum:hl7v2." + version + "." + name;
+                default:          return null;
+            }
+        }
+        if (parts.length == 3 && "schemas".equals(parts[0]) && "shared".equals(parts[1])) {
+            return sharedId.get();   // e.g. schema:shared:hl7v2.message-envelope
+        }
+        return null;
+    }
+
+    private static String stripJson(String fileName) {
+        return fileName.endsWith(".json") ? fileName.substring(0, fileName.length() - ".json".length()) : fileName;
+    }
+
+    private static String readIdFromStream(InputStream in) {
+        if (in == null) {
+            return null;
+        }
+        try (InputStream s = in) {
+            return readIdFromString(new String(s.readAllBytes(), StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    private static String readIdFromString(String json) {
         JsonObject obj = GSON.fromJson(json, JsonObject.class);
         if (obj != null && obj.has("id")) {
             String id = obj.get("id").getAsString();
             if (id.startsWith("schema:")) {
-                byId.put(id, json);
+                return id;
             }
+        }
+        return null;
+    }
+
+    private static String readClasspath(String resource) {
+        InputStream in = SchemaRegistry.class.getResourceAsStream("/" + resource);
+        if (in == null) {
+            throw new UncheckedIOException(new IOException("schema resource vanished: " + resource));
+        }
+        try (InputStream s = in) {
+            return new String(s.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to read schema " + resource, e);
+        }
+    }
+
+    private static String readFile(Path file) {
+        try {
+            return Files.readString(file);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to read schema " + file, e);
         }
     }
 
     /**
      * Merge an extension pack's schemas (DESIGN §7) by walking {@code extDir} for
      * {@code *.json} files carrying a {@code schema:} id. Throws {@link IllegalStateException}
-     * on a duplicate id (the no-dup-across-packs rule, §7.3 boot validation) —
-     * fail fast rather than silently shadow base or peer content.
+     * on a duplicate id (the no-dup-across-packs rule, §7.3 boot validation) — fail
+     * fast rather than silently shadow base or peer content. Extension content is
+     * small and read here, so it is kept in memory rather than re-read on demand.
      */
     public void mergeExtension(Path extDir) {
         if (!Files.isDirectory(extDir)) {
@@ -133,23 +212,15 @@ public final class SchemaRegistry {
         }
         try (Stream<Path> walk = Files.walk(extDir)) {
             walk.filter(p -> p.toString().endsWith(".json")).forEach(file -> {
-                try {
-                    String json = Files.readString(file);
-                    JsonObject obj = GSON.fromJson(json, JsonObject.class);
-                    if (obj == null || !obj.has("id")) {
-                        return;   // manifest.json / structure-index.json carry no schema id
-                    }
-                    String id = obj.get("id").getAsString();
-                    if (!id.startsWith("schema:")) {
-                        return;
-                    }
-                    if (byId.containsKey(id)) {
-                        throw new IllegalStateException("duplicate schema id across extensions: " + id);
-                    }
-                    byId.put(id, json);
-                } catch (IOException e) {
-                    throw new UncheckedIOException("Failed to read extension schema " + file, e);
+                String json = readFile(file);
+                String id = readIdFromString(json);   // manifest.json / structure-index carry no schema id
+                if (id == null) {
+                    return;
                 }
+                if (loaders.containsKey(id)) {
+                    throw new IllegalStateException("duplicate schema id across extensions: " + id);
+                }
+                loaders.put(id, () -> json);
             });
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to scan extension dir " + extDir, e);
@@ -158,19 +229,19 @@ public final class SchemaRegistry {
 
     /** Raw schema JSON for {@code schemaId}, or throw {@code noSuchObjectError}. */
     public String getSchema(String schemaId) {
-        String json = byId.get(schemaId);
-        if (json == null) {
+        Supplier<String> loader = loaders.get(schemaId);
+        if (loader == null) {
             throw ProducerException.noSuchSchema(schemaId);
         }
-        return json;
+        return loader.get();
     }
 
     public boolean has(String schemaId) {
-        return byId.containsKey(schemaId);
+        return loaders.containsKey(schemaId);
     }
 
     public int size() {
-        return byId.size();
+        return loaders.size();
     }
 
     /**
@@ -181,7 +252,7 @@ public final class SchemaRegistry {
     public List<String> messageStructures(String version) {
         String prefix = "schema:table:hl7v2." + version + ".";
         List<String> out = new ArrayList<>();
-        for (String id : byId.keySet()) {
+        for (String id : loaders.keySet()) {
             if (id.startsWith(prefix)) {
                 out.add(id.substring(prefix.length()));
             }
@@ -192,14 +263,13 @@ public final class SchemaRegistry {
 
     /**
      * All message-structure names → their collection schema id, across every
-     * namespace (base {@code v27} + extension namespaces like {@code epic}). Drives
+     * namespace (base version slots + extension namespaces like {@code epic}). Drives
      * the namespace-agnostic {@code /by-type/<X>} listing once extensions are merged.
-     * Insertion order: base then extensions.
      */
     public Map<String, String> messageStructureIds() {
         Map<String, String> out = new LinkedHashMap<>();
         String pre = "schema:table:hl7v2.";
-        for (String id : byId.keySet()) {
+        for (String id : loaders.keySet()) {
             if (id.startsWith(pre)) {
                 String tail = id.substring(pre.length());      // <namespace>.<name>
                 int dot = tail.indexOf('.');

--- a/package/hl7/v2/java/src/test/java/com/zerobias/module/hl7/ext/ExtensionLoaderIT.java
+++ b/package/hl7/v2/java/src/test/java/com/zerobias/module/hl7/ext/ExtensionLoaderIT.java
@@ -7,7 +7,9 @@ import ca.uhn.hl7v2.parser.GenericModelClassFactory;
 import ca.uhn.hl7v2.validation.impl.ValidationContextFactory;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
+import com.zerobias.module.hl7.buffer.BufferRow;
 import com.zerobias.module.hl7.buffer.BufferStore;
+import com.zerobias.module.hl7.buffer.MessageStatus;
 import com.zerobias.module.hl7.materializer.Materializer;
 import com.zerobias.module.hl7.materializer.StructureIndex;
 import com.zerobias.module.hl7.materializer.StructureResolver;
@@ -18,6 +20,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -108,12 +111,19 @@ class ExtensionLoaderIT {
             scopes.put(d.structure(), d.whereClause());
         }
         try (BufferStore buffer = new BufferStore(dbDir.resolve("buffer.db").toString(), false)) {
+            // A received base ADT_A01 (base structures are buffer-driven now); it also
+            // matches the epic discriminator, so both must surface under /by-type.
+            buffer.insert(new BufferRow(0, Instant.parse("2026-05-28T10:00:00Z"), "B1",
+                "ADT_A01", "ADT", "A01", "EPIC", "HOSP", "2.7", "schema:table:hl7v2.v27.ADT_A01",
+                "raw".getBytes(), "{}", MessageStatus.NEW, null, null, null));
+
             ObjectTree tree = new ObjectTree(buffer, registry, "v27", scopes);
             List<String> byType = tree.children("/hl7-v2-receiver/by-type").stream()
                 .map(o -> o.get("id").toString()).toList();
             assertTrue(byType.contains("/hl7-v2-receiver/by-type/ADT_A01_with_ZPV"),
                 "augmented structure listed: " + byType);
-            assertTrue(byType.contains("/hl7-v2-receiver/by-type/ADT_A01"), "base structure still listed");
+            assertTrue(byType.contains("/hl7-v2-receiver/by-type/ADT_A01"),
+                "base structure still listed (not hidden by the extension): " + byType);
 
             // the extension collection scopes by the discriminator, not message_structure
             ObjectTree.Collection coll = tree.resolveCollection("/hl7-v2-receiver/by-type/ADT_A01_with_ZPV");

--- a/package/hl7/v2/java/src/test/java/com/zerobias/module/hl7/filter/Hl7SqlAdapterIT.java
+++ b/package/hl7/v2/java/src/test/java/com/zerobias/module/hl7/filter/Hl7SqlAdapterIT.java
@@ -19,6 +19,7 @@ import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -30,9 +31,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * running both over the same seeded buffer.
  *
  * <p>Parity is asserted only for operators the evaluator actually supports.
- * (The evaluator's {@code >}/{@code >=} are numeric-only and throw on date
- * strings, so {@code receivedAt>=<ISO>} is SQL-only — exercised separately in
- * {@link #designExampleFiltersRunOnSqlite}.)
+ * (As of lite-filter 1.0.4 the evaluator's {@code >}/{@code >=} compare ISO-8601
+ * strings lexicographically — which matches chronological order — so a
+ * {@code receivedAt>=<ISO>} datetime works in-memory too; its epoch-millis SQL
+ * rendering is exercised in {@link #timeOfDayInComparisonRendersEpochMillis}.)
  */
 class Hl7SqlAdapterIT {
 
@@ -148,9 +150,8 @@ class Hl7SqlAdapterIT {
         try (BufferStore store = load(dir, msgs)) {
             // §2.6 example 1: ADT from EPIC, since 2026-05-27, un-acked. Uses the
             // date-only form the interface's FilterSyntax.md documents
-            // (modified>=2025-01-01) — a full ISO datetime is NOT parseable, see
-            // parserRejectsTimeOfDayInComparison(). receivedAt>= is SQL-only
-            // (the evaluator can't compare date strings).
+            // (modified>=2025-01-01); the full ISO-datetime form is covered by
+            // timeOfDayInComparisonRendersEpochMillis().
             String f1 = "(&(msh.sendingApplication.namespaceId=EPIC)"
                 + "(msh.messageType.messageCode=ADT)"
                 + "(receivedAt>=2026-05-27)"
@@ -170,14 +171,21 @@ class Hl7SqlAdapterIT {
     }
 
     @Test
-    void parserRejectsTimeOfDayInComparison() {
-        // Locks a real lite-filter limitation: its RFC4515 parser treats the first
-        // colon as the start of a :function: operator, so an ISO datetime value
-        // (2026-05-27T00:00:00Z) in a >= clause is mis-read as operator ':00:'.
-        // Date-only literals and the :withinDays:/:year: extensions are the
-        // supported ways to filter by time. (Fixing the parser is org/util scope.)
-        assertThrows(IllegalArgumentException.class,
-            () -> Hl7Filter.parse("(receivedAt>=2026-05-27T00:00:00Z)"));
+    void timeOfDayInComparisonRendersEpochMillis(@TempDir Path dir) throws Exception {
+        // Regression for the lite-filter parser bug (fixed in lite-filter 1.0.4): the
+        // colons in a full ISO-8601 datetime's time-of-day (00:00:00) used to be
+        // mis-read as a :function: operator, throwing "Unknown operator: :00:". The
+        // datetime now parses and the adapter renders it to the epoch-millis form.
+        String filter = "(receivedAt>=2026-05-27T00:00:00Z)";
+        String where = Hl7Filter.toWhereClause(filter);
+        assertTrue(where.contains("received_at >= (unixepoch('2026-05-27T00:00:00Z') * 1000)"),
+            "time-of-day datetime coerced to epoch-millis: " + where);
+
+        try (BufferStore store = load(dir, seed())) {
+            // M1-M3 are 2026-05-28; M4 is 2025-12-31 and is excluded.
+            assertEquals(new TreeSet<>(List.of("M1", "M2", "M3")), selected(store, where),
+                filter + " -> " + where);
+        }
     }
 
     @Test
@@ -225,5 +233,20 @@ class Hl7SqlAdapterIT {
             () -> Hl7Filter.toWhereClause("(pid.fam-ily=SMITH)")); // hyphen: adapter segment guard
         assertThrows(IllegalArgumentException.class,
             () -> Hl7Filter.toWhereClause("(pid.x');DROP TABLE messages;--=X)"));
+    }
+
+    @Test
+    void provenancePropertiesRenderToDenormalizedColumns() {
+        // The fast search axes (version / port / structure / sender) resolve to real
+        // columns, not json_extract over mapped_json — so multi-axis search is indexed.
+        assertTrue(Hl7Filter.toWhereClause("(hl7Version=2.4)").contains("hl7_version"));
+        assertTrue(Hl7Filter.toWhereClause("(sourcePort=Scheduling SIU)").contains("source_port"));
+        assertTrue(Hl7Filter.toWhereClause("(messageStructure=ADT_A01)").contains("message_structure"));
+        assertTrue(Hl7Filter.toWhereClause("(sendingApp=EPIC)").contains("sending_app"));
+        assertTrue(Hl7Filter.toWhereClause("(sendingFacility=GPAMB)").contains("sending_facility"));
+        assertFalse(Hl7Filter.toWhereClause("(hl7Version=2.4)").contains("json_extract"),
+            "denormalized column, not a JSON path");
+        // A message-body field still routes through json_extract (unchanged).
+        assertTrue(Hl7Filter.toWhereClause("(pid.setIDPID=1)").contains("json_extract"));
     }
 }

--- a/package/hl7/v2/java/src/test/java/com/zerobias/module/hl7/listener/Hl7ListenerIT.java
+++ b/package/hl7/v2/java/src/test/java/com/zerobias/module/hl7/listener/Hl7ListenerIT.java
@@ -60,7 +60,11 @@ class Hl7ListenerIT {
             assertEquals("ADT", row.messageCode());
             assertEquals("A01", row.triggerEvent());
             assertEquals("EPIC", row.sendingApp());
-            assertEquals("schema:table:hl7v2.v27.ADT_A01", row.schemaId());
+            // This IT wires the degraded EnvelopeMaterializer (no structure index), so
+            // the row carries the shared envelope schema rather than a typed table id we
+            // couldn't serve. Typed per-version table-id routing is covered by
+            // MaterializerRegistryIT + the schema-backed producer ITs.
+            assertEquals("schema:shared:hl7v2.message-envelope", row.schemaId());
             assertNotNull(row.rawEr7());
             assertTrue(row.mappedJson().contains("\"patientFamilyName\":\"SMITH\""),
                 "materialized JSON: " + row.mappedJson());

--- a/package/hl7/v2/java/src/test/java/com/zerobias/module/hl7/materializer/MaterializerRegistryIT.java
+++ b/package/hl7/v2/java/src/test/java/com/zerobias/module/hl7/materializer/MaterializerRegistryIT.java
@@ -1,0 +1,70 @@
+package com.zerobias.module.hl7.materializer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Per-message version routing (DESIGN §5 / §11.5): the registry maps each message's
+ * MSH-12 to the right slot, lazily loading bundled indexes and degrading unbundled
+ * versions to the envelope schema. Exercises the baked-in classpath slots (v23–v27).
+ */
+class MaterializerRegistryIT {
+
+    private static Materializer v27() {
+        StructureIndex idx = StructureIndex.fromClasspath("v27");
+        assertNotNull(idx, "v27 structure-index must be on the classpath");
+        return new Materializer(idx);
+    }
+
+    @Test
+    void routesEachVersionToItsOwnBundledSlot() {
+        MaterializerRegistry r = MaterializerRegistry.routing("v27", v27(), true);
+
+        // A 2.4 message resolves to the v24 slot: typed, with a v24 table schema id...
+        assertEquals("v24", r.slotFor("2.4"));
+        assertEquals("schema:table:hl7v2.v24.ADT_A01", r.schemaIdFor("2.4", "ADT_A01"));
+        assertTrue(r.materializerFor("2.4") instanceof Materializer,
+            "v24 is bundled → typed materializer, lazily loaded from the classpath");
+
+        // ...and the configured default slot still resolves to its own version.
+        assertEquals("schema:table:hl7v2.v27.ADT_A01", r.schemaIdFor("2.7", "ADT_A01"));
+
+        // 2.5.1 → v251 (multi-dot slot), also bundled.
+        assertEquals("v251", r.slotFor("2.5.1"));
+        assertEquals("schema:table:hl7v2.v251.ORU_R01", r.schemaIdFor("2.5.1", "ORU_R01"));
+    }
+
+    @Test
+    void unbundledVersionDegradesToEnvelopeButIsStillRecorded() {
+        MaterializerRegistry r = MaterializerRegistry.routing("v27", v27(), true);
+
+        assertEquals("v99", r.slotFor("9.9"));   // slot derived even if not bundled
+        assertEquals(MaterializerRegistry.ENVELOPE_SCHEMA, r.schemaIdFor("9.9", "ADT_A01"));
+        assertFalse(r.materializerFor("9.9") instanceof Materializer,
+            "unbundled version → generic materializer, never a drop");
+    }
+
+    @Test
+    void blankOrMissingVersionFallsBackToDefaultSlot() {
+        MaterializerRegistry r = MaterializerRegistry.routing("v27", v27(), true);
+        assertEquals("v27", r.slotFor(null));
+        assertEquals("v27", r.slotFor(""));
+        assertEquals("schema:table:hl7v2.v27.ADT_A01", r.schemaIdFor(null, "ADT_A01"));
+    }
+
+    @Test
+    void pinnedIgnoresMsh12() {
+        // Config-fixed deployment: one slot for everything, regardless of MSH-12.
+        MaterializerRegistry typed = MaterializerRegistry.pinned("v27", v27());
+        assertEquals("v27", typed.slotFor("2.4"));
+        assertEquals("schema:table:hl7v2.v27.ADT_A01", typed.schemaIdFor("2.4", "ADT_A01"));
+
+        // A degraded (no-index) pin carries the envelope schema, not a table id it can't serve.
+        MaterializerRegistry envelope = MaterializerRegistry.pinned("v27", new EnvelopeMaterializer());
+        assertEquals(MaterializerRegistry.ENVELOPE_SCHEMA, envelope.schemaIdFor("2.7", "ADT_A01"));
+    }
+}

--- a/package/hl7/v2/java/src/test/java/com/zerobias/module/hl7/producer/Hl7ProducerIT.java
+++ b/package/hl7/v2/java/src/test/java/com/zerobias/module/hl7/producer/Hl7ProducerIT.java
@@ -110,7 +110,7 @@ class Hl7ProducerIT {
         assertEquals(1, rootChildren.size());
         assertEquals("/hl7-v2-receiver", rootChildren.get(0).getAsJsonObject().get("id").getAsString());
 
-        // receiver has exactly: messages, by-type, by-sender, by-port, stats, ops
+        // receiver has exactly: messages, by-type, by-version, by-sender, by-port, stats, ops
         JsonArray kids = pagedItems(
             op(f, "ObjectsApi.getChildren", "objectId", "/hl7-v2-receiver"));
         java.util.Set<String> kidIds = kids.asList().stream()
@@ -119,6 +119,7 @@ class Hl7ProducerIT {
         assertEquals(java.util.Set.of(
             "/hl7-v2-receiver/messages",
             "/hl7-v2-receiver/by-type",
+            "/hl7-v2-receiver/by-version",
             "/hl7-v2-receiver/by-sender",
             "/hl7-v2-receiver/by-port",
             "/hl7-v2-receiver/stats",
@@ -135,16 +136,16 @@ class Hl7ProducerIT {
         JsonObject env = GSON.fromJson(
             op(f, "ObjectsApi.getChildren", "objectId", "/hl7-v2-receiver",
                 "pageSize", 2, "pageNumber", 1), JsonObject.class);
-        assertEquals(6, env.get("count").getAsInt());           // 6 children total
+        assertEquals(7, env.get("count").getAsInt());           // 7 children total
         assertEquals(2, env.get("pageSize").getAsInt());
         assertEquals(1, env.get("pageNumber").getAsInt());      // 1-based, echoed
-        assertEquals(2, env.getAsJsonArray("items").size());    // first page: 2 of 6
+        assertEquals(2, env.getAsJsonArray("items").size());    // first page: 2 of 7
 
         // page 3 (1-based) of size 2 -> the trailing 2 children, count unchanged
         JsonObject p3 = GSON.fromJson(
             op(f, "ObjectsApi.getChildren", "objectId", "/hl7-v2-receiver",
                 "pageSize", 2, "pageNumber", 3), JsonObject.class);
-        assertEquals(6, p3.get("count").getAsInt());
+        assertEquals(7, p3.get("count").getAsInt());
         assertEquals(2, p3.getAsJsonArray("items").size());
 
         // collection elements are paged the same way — total count, not page size
@@ -230,7 +231,8 @@ class Hl7ProducerIT {
             op(f, "CollectionsApi.searchCollectionElements", "objectId", "/hl7-v2-receiver/messages"));
         assertEquals(3, all.size());
 
-        // scoped to ADT_A01 -> M1, M2
+        // ADT_A01 has a single version here, so /by-type/ADT_A01 is itself the
+        // (homogeneous) collection — no version discriminator needed. -> M1, M2
         JsonArray adt = pagedItems(
             op(f, "CollectionsApi.searchCollectionElements",
                 "objectId", "/hl7-v2-receiver/by-type/ADT_A01"));
@@ -307,6 +309,52 @@ class Hl7ProducerIT {
         assertEquals(400, e5.httpStatus());
         assertEquals("err.illegal.argument", e5.key());
         assertIllegalArgumentBody(e5.toBody());
+    }
+
+    @Test
+    void byTypeIsVersionNestedAndByVersionFacet(@TempDir Path dir) throws Exception {
+        BufferStore buffer = new BufferStore(dir.resolve("buffer.db").toString(), false);
+        writeSchema(dir, "schemas/v27/messages/ADT_A01.json", "schema:table:hl7v2.v27.ADT_A01");
+        writeSchema(dir, "schemas/v24/messages/ADT_A01.json", "schema:table:hl7v2.v24.ADT_A01");
+        SchemaRegistry schemas = SchemaRegistry.fromDirectory(dir);
+        insertVersioned(buffer, "A", "2.7");
+        insertVersioned(buffer, "B", "2.4");
+        Hl7ProducerFacade f = new Hl7ProducerFacade(buffer, new ObjectTree(buffer, schemas, "v27"), schemas);
+
+        // /by-type/ADT_A01 is a CONTAINER whose children are the versions received.
+        JsonObject typeNode = GSON.fromJson(
+            op(f, "ObjectsApi.getObject", "objectId", "/hl7-v2-receiver/by-type/ADT_A01"), JsonObject.class);
+        assertEquals(List.of("container"), classes(typeNode));
+        List<String> vers = pagedItems(op(f, "ObjectsApi.getChildren",
+            "objectId", "/hl7-v2-receiver/by-type/ADT_A01")).asList().stream()
+            .map(e -> e.getAsJsonObject().get("id").getAsString()).toList();
+        assertEquals(List.of("/hl7-v2-receiver/by-type/ADT_A01/2.4",
+                             "/hl7-v2-receiver/by-type/ADT_A01/2.7"), vers);
+
+        // The version leaf is a HOMOGENEOUS collection carrying the version-correct schema.
+        JsonObject leaf = GSON.fromJson(
+            op(f, "ObjectsApi.getObject", "objectId", "/hl7-v2-receiver/by-type/ADT_A01/2.4"), JsonObject.class);
+        assertEquals(List.of("collection"), classes(leaf));
+        assertEquals("schema:table:hl7v2.v24.ADT_A01", leaf.get("collectionSchema").getAsString());
+        JsonArray leafRows = pagedItems(op(f, "CollectionsApi.searchCollectionElements",
+            "objectId", "/hl7-v2-receiver/by-type/ADT_A01/2.4"));
+        assertEquals(1, leafRows.size());
+        assertEquals("B", leafRows.get(0).getAsJsonObject().get("controlId").getAsString());
+
+        // /by-version lists each version; a version collection is heterogeneous (envelope schema).
+        List<String> byVer = pagedItems(op(f, "ObjectsApi.getChildren",
+            "objectId", "/hl7-v2-receiver/by-version")).asList().stream()
+            .map(e -> e.getAsJsonObject().get("id").getAsString()).toList();
+        assertEquals(List.of("/hl7-v2-receiver/by-version/2.4", "/hl7-v2-receiver/by-version/2.7"), byVer);
+        JsonObject v24 = GSON.fromJson(
+            op(f, "ObjectsApi.getObject", "objectId", "/hl7-v2-receiver/by-version/2.4"), JsonObject.class);
+        assertEquals("schema:shared:hl7v2.message-envelope", v24.get("collectionSchema").getAsString());
+    }
+
+    private static void insertVersioned(BufferStore b, String cid, String version) throws Exception {
+        b.insert(new BufferRow(0, Instant.parse("2026-05-28T10:00:00Z"), cid, "ADT_A01", "ADT", "A01",
+            "EPIC", "HOSP", version, "schema:table:hl7v2.v" + version.replace(".", "") + ".ADT_A01",
+            ("raw-" + cid).getBytes(), "{}", MessageStatus.NEW, null, null, null));
     }
 
     /** errorModelBase required fields are present, non-null, and well-typed. */

--- a/package/hl7/v2/java/src/test/java/com/zerobias/module/hl7/producer/Hl7RecastIT.java
+++ b/package/hl7/v2/java/src/test/java/com/zerobias/module/hl7/producer/Hl7RecastIT.java
@@ -1,0 +1,178 @@
+package com.zerobias.module.hl7.producer;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.zerobias.module.hl7.buffer.BufferRow;
+import com.zerobias.module.hl7.buffer.BufferStore;
+import com.zerobias.module.hl7.buffer.MessageStatus;
+import com.zerobias.module.hl7.materializer.Materializer;
+import com.zerobias.module.hl7.materializer.MaterializerRegistry;
+import com.zerobias.module.hl7.materializer.StructureIndex;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * {@code ops/recast} (DESIGN §2.5): re-materialize stored rows from their retained
+ * raw ER7 under the current schema, driven through {@code FunctionsApi.invokeFunction}
+ * on {@link OperationRouter} — the exact HTTP code path — over a real SQLite buffer
+ * and the real v27 {@link Materializer}.
+ *
+ * <p>Seeds rows with a deliberately degraded {@code mapped_json} ("{}", as an
+ * envelope-fallback or pre-extension cast would leave it) and asserts recast
+ * upgrades exactly the rows that improve, is idempotent, skips leased rows, honors
+ * the filter, and survives an un-parseable raw.
+ */
+class Hl7RecastIT {
+
+    private static final Gson GSON = new Gson();
+    private static final String CR = "\r";
+
+    /** A well-formed ADT^A01 (structure ADT_A01) — full materialization yields msh/pid/pv1. */
+    private static final String ADT_ER7 = String.join(CR,
+        "MSH|^~\\&|EPIC|HOSP|RECV|DEST|20260529103000||ADT^A01^ADT_A01|MSG1|P|2.7",
+        "EVN|A01|20260529103000",
+        "PID|1||5551212^^^EPIC&&ISO^MR||SMITH^JOHN||19800101|M",
+        "PV1|1|I") + CR;
+
+    private BufferStore buffer;
+
+    /** Facade wired with the real v27 materializer-backed {@link Recaster}. */
+    private Hl7ProducerFacade facade(Path dir) throws Exception {
+        StructureIndex index = StructureIndex.fromClasspath("v27");
+        if (index == null) {
+            String idxDir = System.getenv("HL7_INDEX_DIR");
+            assumeTrue(idxDir != null && !idxDir.isBlank(),
+                "no classpath structure-index and HL7_INDEX_DIR unset; skipping");
+            index = StructureIndex.fromFile(Path.of(idxDir, "structure-index", "v27.json"));
+        }
+        Recaster recaster = new Recaster(MaterializerRegistry.pinned("v27", new Materializer(index)));
+
+        buffer = new BufferStore(dir.resolve("buffer.db").toString(), false);
+        Files.createDirectories(dir.resolve("schemas"));
+        SchemaRegistry schemas = SchemaRegistry.fromDirectory(dir);
+        return new Hl7ProducerFacade(buffer, new ObjectTree(buffer, schemas, "v27"), schemas, recaster);
+    }
+
+    /** Insert a row carrying real raw ER7 but a degraded (empty) stored mapped_json. */
+    private void insertDegraded(String cid, String rawEr7, MessageStatus status) throws Exception {
+        buffer.insert(new BufferRow(0, Instant.parse("2026-05-28T10:00:00Z"), cid, "ADT_A01", "ADT", "A01",
+            "EPIC", "HOSP", "2.7", "schema:table:hl7v2.v27.ADT_A01", rawEr7.getBytes(),
+            "{}", status, null, null, null));
+    }
+
+    private JsonObject invoke(Hl7ProducerFacade f, String fn, Map<String, Object> input) throws Exception {
+        Map<String, Object> args = new LinkedHashMap<>();
+        args.put("objectId", "/hl7-v2-receiver/ops/" + fn);
+        args.put("requestBody", input);
+        return GSON.fromJson(OperationRouter.executeOperation(f, "FunctionsApi.invokeFunction", args),
+            JsonObject.class);
+    }
+
+    private BufferRow row(String cid) throws Exception {
+        return buffer.search("control_id = '" + cid + "'", 1).get(0);
+    }
+
+    @Test
+    void recastUpgradesDegradedJson(@TempDir Path dir) throws Exception {
+        Hl7ProducerFacade f = facade(dir);
+        insertDegraded("M1", ADT_ER7, MessageStatus.NEW);
+        insertDegraded("M2", ADT_ER7, MessageStatus.ACKED);   // acked rows are recast too
+
+        JsonObject r = invoke(f, "recast", Map.of());
+        assertEquals(2, r.get("examined").getAsInt());
+        assertEquals(2, r.get("recast").getAsInt());
+        assertEquals(0, r.get("unchanged").getAsInt());
+        assertEquals(0, r.get("failed").getAsInt());
+
+        // the degraded "{}" is replaced by the full typed body
+        assertTrue(row("M1").mappedJson().contains("\"pid\""), "M1 upgraded: " + row("M1").mappedJson());
+        assertTrue(row("M2").mappedJson().contains("\"pid\""), "M2 upgraded");
+    }
+
+    @Test
+    void recastIsIdempotent(@TempDir Path dir) throws Exception {
+        Hl7ProducerFacade f = facade(dir);
+        insertDegraded("M1", ADT_ER7, MessageStatus.NEW);
+
+        invoke(f, "recast", Map.of());                        // first pass upgrades it
+        String afterFirst = row("M1").mappedJson();
+
+        JsonObject second = invoke(f, "recast", Map.of());    // nothing left to improve
+        assertEquals(1, second.get("examined").getAsInt());
+        assertEquals(0, second.get("recast").getAsInt());
+        assertEquals(1, second.get("unchanged").getAsInt());
+        assertEquals(afterFirst, row("M1").mappedJson(), "unchanged row not rewritten");
+    }
+
+    @Test
+    void recastSkipsInFlight(@TempDir Path dir) throws Exception {
+        Hl7ProducerFacade f = facade(dir);
+        insertDegraded("M1", ADT_ER7, MessageStatus.NEW);
+        insertDegraded("M2", ADT_ER7, MessageStatus.NEW);
+        buffer.takeWhere(null, 1, Duration.ofMinutes(5));     // lease one row -> in_flight
+
+        JsonObject r = invoke(f, "recast", Map.of());
+        assertEquals(1, r.get("examined").getAsInt(), "the leased row is excluded");
+        assertEquals(1, r.get("recast").getAsInt());
+
+        List<BufferRow> leased = buffer.search("status = 'in_flight'", 10);
+        assertEquals(1, leased.size());
+        assertEquals("{}", leased.get(0).mappedJson(), "leased row left untouched mid-flight");
+    }
+
+    @Test
+    void recastHonorsFilter(@TempDir Path dir) throws Exception {
+        Hl7ProducerFacade f = facade(dir);
+        insertDegraded("M1", ADT_ER7, MessageStatus.NEW);
+        // controlId is a denormalized envelope column, so the scope holds even while the
+        // row's mapped_json is still the degraded "{}" (a body-path filter could not).
+        JsonObject none = invoke(f, "recast", Map.of("filter", "(controlId=NOPE)"));
+        assertEquals(0, none.get("examined").getAsInt());
+        assertEquals(0, none.get("recast").getAsInt());
+        assertEquals("{}", row("M1").mappedJson(), "filtered out, not recast");
+
+        JsonObject match = invoke(f, "recast", Map.of("filter", "(controlId=M1)"));
+        assertEquals(1, match.get("examined").getAsInt());
+        assertEquals(1, match.get("recast").getAsInt());
+    }
+
+    @Test
+    void recastCountsUnparseableRawAsFailedNotFatal(@TempDir Path dir) throws Exception {
+        Hl7ProducerFacade f = facade(dir);
+        insertDegraded("BAD", "this is not an HL7 message", MessageStatus.NEW);
+        insertDegraded("M1", ADT_ER7, MessageStatus.NEW);
+
+        JsonObject r = invoke(f, "recast", Map.of());
+        assertEquals(2, r.get("examined").getAsInt());
+        assertEquals(1, r.get("recast").getAsInt(), "the good row still upgrades");
+        assertEquals(1, r.get("failed").getAsInt(), "the bad raw is counted, not thrown");
+        assertEquals("{}", row("BAD").mappedJson(), "failed row left as-is");
+    }
+
+    @Test
+    void recastUnavailableWithoutMaterializer(@TempDir Path dir) throws Exception {
+        // A facade built without a Recaster (back-compat 3-arg ctor) rejects recast.
+        buffer = new BufferStore(dir.resolve("buffer.db").toString(), false);
+        Files.createDirectories(dir.resolve("schemas"));
+        SchemaRegistry schemas = SchemaRegistry.fromDirectory(dir);
+        Hl7ProducerFacade f = new Hl7ProducerFacade(buffer, new ObjectTree(buffer, schemas, "v27"), schemas);
+        insertDegraded("M1", ADT_ER7, MessageStatus.NEW);
+
+        ProducerException e = assertThrows(ProducerException.class, () -> invoke(f, "recast", Map.of()));
+        assertEquals(400, e.httpStatus());
+        assertEquals("err.unsupported.operation", e.key());
+    }
+}

--- a/package/hl7/v2/package-lock.json
+++ b/package/hl7/v2/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zerobias-org/module-hl7-v2",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zerobias-org/module-hl7-v2",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "UNLICENSED",
       "dependencies": {
         "@zerobias-org/module-interface-dataproducer": "^2.1.5",


### PR DESCRIPTION
Three parts of one effort: serve a mixed-version HL7 feed, filter it by datetime, and repair already-buffered rows when a better schema ships. They land together because each is incomplete without the others (you can't ship a schema improvement without a way to re-cast the data already in the buffer under it).

## 1. Multi-version structure support (the headline)
Previously the module generated and loaded a single version slot (v27) and materialized every inbound message against it.

- **Codegen now generates a structure index + schema tree for every bundled version** — `v23, v231, v24, v25, v251, v26, v27` — not just v27 (`SchemaGenerator`/`StructureWalker`/`HapiNames` + the codegen arg in `java/pom.xml`). The supported-version list is that codegen arg; the generated indexes are baked into the jar (gitignored, produced at build time).
- **`MaterializerRegistry` routes each inbound message by its own MSH-12 version**: the configured default slot uses the extension-merged materializer; any other version's slot is loaded lazily from the classpath; a version whose slot isn't bundled degrades to the generic envelope materializer + envelope schema (buffered and searchable, never dropped). `BufferingApp`, `Hl7ApiServer`, `SchemaRegistry`, `ObjectTree`, and `Hl7SqlAdapter` updated to route/label per message version.

## 2. ISO-datetime filters (lite-filter 1.0.0 → 1.0.4)
Picks up the RFC4515 parser fix where colons inside a value (an ISO-8601 time-of-day like `13:00:00`, or `schema:table:` ids) were mis-read as a `:function:` operator (`Unknown operator: :00:`). Unblocks datetime-range filters such as `(receivedAt>=2026-07-04T13:00:00Z)`. Test flipped from locking the old bug to asserting the epoch-millis rendering.

## 3. ops/recast
When a better schema ships, rows already in the buffer stay frozen at their original (poorer) quality — the module version is unchanged, so nothing re-materializes them. `ops/recast` fixes them in place.

A DataProducer function op (same shape as `replay`) that re-parses each row's retained `raw_er7` and re-materializes it **through the `MaterializerRegistry`, routing by the row's own version** — so a row first cast under a poorer/envelope schema upgrades to the best schema now bundled for its version.

- **Only-if-improved**: rewrites `mapped_json`/`schema_id` only where the result changed — idempotent.
- **Skips leased (`in_flight`) rows** (update guarded on `status <> 'in_flight'` to close the select→update race).
- **Failure-tolerant**: a per-row parse/materialize failure is counted, never fatal.
- Returns `{examined, recast, unchanged, failed}`; up to `max` rows (newest first) per call, optional RFC4515 `filter`.

## Verification
`mvn clean verify`: BUILD SUCCESS — 44 unit + 45 integration + codegen tests, 0 failures. Codegen emits all seven version indexes (v23–v27) into the jar. New `Hl7RecastIT` (6/6) and `MaterializerRegistryIT`; existing suites updated for per-version routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)