### PR TITLE
docs(claude): flag OAuth click-to-connect as two-half capability

### DIFF
--- a/.claude/agents/credential-manager.md
+++ b/.claude/agents/credential-manager.md
@@ -159,13 +159,19 @@ Identify auth method from API documentation and credentials:
   loadable via the dataloader like any content (reuse an existing provider —
   `microsoft`/`github`/`atlassian`/`slack`/`zoho`/`google` — or add a new one). The **only
   insider layer** is (3) registering the external OAuth app + putting client_id/secret in AWS
-  Secrets Manager (secrets can't be content). When you identify this auth method you MUST set
-  `requiresPlatformOAuthRegistration: true`, pick the `oauthProviderCode` (reuse e.g.
-  `microsoft.oauth` when it fits), and tell the user to open the layer-3 task — see the "OAuth
-  Click-to-Connect — 3 layers" section in @.claude/skills/connection-profile/SKILL.md for the
-  task template AND the verified reference modules to copy (`msgraph` for Entra/Azure AD, `jira`,
-  `slack`, `github`). (OAuth **client-credentials** does NOT need any of layers 2–3 — no popup,
-  no provider link, fully self-serve; e.g. Wiz uses a `client_credentials` service account via
+  Secrets Manager (secrets can't be content). When you identify this auth method you MUST:
+  1. **Detect whether the provider already exists in `zerobias-org/oauth`** — query it live, don't
+     guess: `gh api repos/zerobias-org/oauth/contents/package --jq '.[].name'` (and the recursive
+     tree for nested providers). Set `oauthProviderCode` + `oauthProviderExists: true|false`.
+  2. If it's **missing**, set `requiresNewOAuthProvider: true` — the provider must be **added** as a
+     separate `zerobias-org/oauth` content PR (contributor content, use the recipe in the skill),
+     and flag it as an extra deliverable. If it exists, just reuse the code.
+  3. Set `requiresPlatformOAuthRegistration: true` and tell the user to open the layer-3 (insider)
+     task. See the "OAuth Click-to-Connect — 3 layers" section (detection step + provider recipe +
+     task template) in @.claude/skills/connection-profile/SKILL.md AND the verified reference
+     modules to copy (`msgraph` for Entra/Azure AD, `jira`, `slack`, `github`).
+  (OAuth **client-credentials** does NOT need any of layers 2–3 — no popup, no provider, no
+  detection, fully self-serve; e.g. Wiz uses a `client_credentials` service account via
   `auth.app.wiz.io`, so it is Pattern 2, not authorization_code.)
 
 ### Basic Auth
@@ -204,9 +210,11 @@ For an **OAuth authorization_code** module, `forApiArchitect` additionally carri
   "forApiArchitect": {
     "authMethodType": "oauth2-authorization-code",
     "requiresRefresh": true,
-    "requiresPlatformOAuthRegistration": true,
     "oauthProviderCode": "microsoft.oauth",
-    "additionalContext": "Click-to-Connect. Module + oauth provider artifact + x-oauth-providers link are all contributor content-as-code; ONLY the external OAuth app registration + client_id/secret in Secrets Manager is a ZeroBias insider task — surface that task to the user."
+    "oauthProviderExists": true,
+    "requiresNewOAuthProvider": false,
+    "requiresPlatformOAuthRegistration": true,
+    "additionalContext": "Click-to-Connect. Module + oauth provider artifact + x-oauth-providers link are all contributor content-as-code; if requiresNewOAuthProvider, add the provider via a zerobias-org/oauth content PR. ONLY the external OAuth app registration + client_id/secret in Secrets Manager is a ZeroBias insider task — surface that task to the user."
   }
 ```
 

--- a/.claude/agents/credential-manager.md
+++ b/.claude/agents/credential-manager.md
@@ -160,9 +160,10 @@ Identify auth method from API documentation and credentials:
   the `oauthProviderCode` (reuse an existing provider like `microsoft.oauth` when it fits),
   and tell the user to open the registration task — see the "OAuth Click-to-Connect = Module
   Half + Platform Half" section in @.claude/skills/connection-profile/SKILL.md for the task
-  template AND the verified reference modules to copy (`msgraph` for Entra/Azure AD — closest
-  Wiz analog, `jira`, `slack`, `github`). (OAuth **client-credentials** does NOT need this — no
-  popup, no provider link.)
+  template AND the verified reference modules to copy (`msgraph` for Entra/Azure AD, `jira`,
+  `slack`, `github`). (OAuth **client-credentials** does NOT need this — no popup, no provider
+  link, fully self-serve; e.g. Wiz uses a `client_credentials` service account via
+  `auth.app.wiz.io`, so it is Pattern 2, not authorization_code.)
 
 ### Basic Auth
 - Username + password in Authorization header

--- a/.claude/agents/credential-manager.md
+++ b/.claude/agents/credential-manager.md
@@ -151,6 +151,16 @@ Identify auth method from API documentation and credentials:
 - Access token + refresh token
 - Pattern: Authorization flow with refresh capability
 - Credentials: CLIENT_ID + CLIENT_SECRET + REFRESH_TOKEN
+- 🚨 **Two-half capability — flag it.** The Hub "Connect" (click-to-authorize) button
+  needs a **platform-side OAuth app registration that a contributor CANNOT self-serve**
+  (OAuth app + client_id/secret in AWS Secrets Manager + `OAuthProvider` load + profile→provider
+  link). The module half you CAN author is: `oauthTokenProfile` + `oauthTokenState` +
+  `x-oauth-providers: [<vendor>.oauth]` + `connect()/refresh()`. When you identify this
+  auth method you MUST set `requiresPlatformOAuthRegistration: true` in your output, pick
+  the `oauthProviderCode` (reuse an existing provider like `microsoft.oauth` when it fits),
+  and tell the user to open the registration task — see the "OAuth Click-to-Connect = Module
+  Half + Platform Half" section in @.claude/skills/connection-profile/SKILL.md for the task
+  template. (OAuth **client-credentials** does NOT need this — no popup, no provider link.)
 
 ### Basic Auth
 - Username + password in Authorization header
@@ -182,11 +192,29 @@ Identify auth method from API documentation and credentials:
 }
 ```
 
+For an **OAuth authorization_code** module, `forApiArchitect` additionally carries:
+
+```json
+  "forApiArchitect": {
+    "authMethodType": "oauth2-authorization-code",
+    "requiresRefresh": true,
+    "requiresPlatformOAuthRegistration": true,
+    "oauthProviderCode": "microsoft.oauth",
+    "additionalContext": "Click-to-Connect. Module half is authorable; platform-side OAuth app + secret + provider link is a ZeroBias insider task — surface the registration task to the user."
+  }
+```
+
 **Pass this data to @api-architect** who will:
 - Select appropriate core profile to extend
 - Design connectionProfile.yml schema
 - Design connectionState.yml schema
 - Configure security schemes in api.yml
+- For authorization_code: add `x-oauth-providers: [<oauthProviderCode>]` to the profile
+
+**When `requiresPlatformOAuthRegistration` is true, also surface to the USER** (not just
+@api-architect): the module ships OAuth-capable, but the Hub "Connect" button stays dark
+until a ZeroBias insider completes the registration task. Hand them the ready-to-file task
+body from @.claude/skills/connection-profile/SKILL.md.
 
 ## Common Patterns
 

--- a/.claude/agents/credential-manager.md
+++ b/.claude/agents/credential-manager.md
@@ -151,18 +151,21 @@ Identify auth method from API documentation and credentials:
 - Access token + refresh token
 - Pattern: Authorization flow with refresh capability
 - Credentials: CLIENT_ID + CLIENT_SECRET + REFRESH_TOKEN
-- 🚨 **Two-half capability — flag it.** The Hub "Connect" (click-to-authorize) button
-  needs a **platform-side OAuth app registration that a contributor CANNOT self-serve**
-  (OAuth app + client_id/secret in AWS Secrets Manager + `OAuthProvider` load + profile→provider
-  link). The module half you CAN author is: `oauthTokenProfile` + `oauthTokenState` +
-  `x-oauth-providers: [<vendor>.oauth]` + `connect()/refresh()`. When you identify this
-  auth method you MUST set `requiresPlatformOAuthRegistration: true` in your output, pick
-  the `oauthProviderCode` (reuse an existing provider like `microsoft.oauth` when it fits),
-  and tell the user to open the registration task — see the "OAuth Click-to-Connect = Module
-  Half + Platform Half" section in @.claude/skills/connection-profile/SKILL.md for the task
-  template AND the verified reference modules to copy (`msgraph` for Entra/Azure AD, `jira`,
-  `slack`, `github`). (OAuth **client-credentials** does NOT need this — no popup, no provider
-  link, fully self-serve; e.g. Wiz uses a `client_credentials` service account via
+- 🚨 **3-layer capability — flag it.** The Hub "Connect" (click-to-authorize) button spans
+  three layers; **only one is insider.** You (contributor) author: (1) the module
+  (`oauthTokenProfile` + `oauthTokenState` + `x-oauth-providers: [<vendor>.oauth]` +
+  `connect()/refresh()`), and (2) the **provider wiring as content-as-code** — the `oauth`
+  artifact (`@zerobias-org/oauth-<vendor>`, `index.yml {id,url}`) + the `x-oauth-providers` link,
+  loadable via the dataloader like any content (reuse an existing provider —
+  `microsoft`/`github`/`atlassian`/`slack`/`zoho`/`google` — or add a new one). The **only
+  insider layer** is (3) registering the external OAuth app + putting client_id/secret in AWS
+  Secrets Manager (secrets can't be content). When you identify this auth method you MUST set
+  `requiresPlatformOAuthRegistration: true`, pick the `oauthProviderCode` (reuse e.g.
+  `microsoft.oauth` when it fits), and tell the user to open the layer-3 task — see the "OAuth
+  Click-to-Connect — 3 layers" section in @.claude/skills/connection-profile/SKILL.md for the
+  task template AND the verified reference modules to copy (`msgraph` for Entra/Azure AD, `jira`,
+  `slack`, `github`). (OAuth **client-credentials** does NOT need any of layers 2–3 — no popup,
+  no provider link, fully self-serve; e.g. Wiz uses a `client_credentials` service account via
   `auth.app.wiz.io`, so it is Pattern 2, not authorization_code.)
 
 ### Basic Auth
@@ -203,7 +206,7 @@ For an **OAuth authorization_code** module, `forApiArchitect` additionally carri
     "requiresRefresh": true,
     "requiresPlatformOAuthRegistration": true,
     "oauthProviderCode": "microsoft.oauth",
-    "additionalContext": "Click-to-Connect. Module half is authorable; platform-side OAuth app + secret + provider link is a ZeroBias insider task — surface the registration task to the user."
+    "additionalContext": "Click-to-Connect. Module + oauth provider artifact + x-oauth-providers link are all contributor content-as-code; ONLY the external OAuth app registration + client_id/secret in Secrets Manager is a ZeroBias insider task — surface that task to the user."
   }
 ```
 

--- a/.claude/agents/credential-manager.md
+++ b/.claude/agents/credential-manager.md
@@ -171,8 +171,8 @@ Identify auth method from API documentation and credentials:
      task template) in @.claude/skills/connection-profile/SKILL.md AND the verified reference
      modules to copy (`msgraph` for Entra/Azure AD, `jira`, `slack`, `github`).
   (OAuth **client-credentials** does NOT need any of layers 2–3 — no popup, no provider, no
-  detection, fully self-serve; e.g. Wiz uses a `client_credentials` service account via
-  `auth.app.wiz.io`, so it is Pattern 2, not authorization_code.)
+  detection, fully self-serve; e.g. a product whose API uses a `client_credentials` service
+  account (Client ID + Secret) is Pattern 2, not authorization_code.)
 
 ### Basic Auth
 - Username + password in Authorization header

--- a/.claude/agents/credential-manager.md
+++ b/.claude/agents/credential-manager.md
@@ -160,7 +160,9 @@ Identify auth method from API documentation and credentials:
   the `oauthProviderCode` (reuse an existing provider like `microsoft.oauth` when it fits),
   and tell the user to open the registration task — see the "OAuth Click-to-Connect = Module
   Half + Platform Half" section in @.claude/skills/connection-profile/SKILL.md for the task
-  template. (OAuth **client-credentials** does NOT need this — no popup, no provider link.)
+  template AND the verified reference modules to copy (`msgraph` for Entra/Azure AD — closest
+  Wiz analog, `jira`, `slack`, `github`). (OAuth **client-credentials** does NOT need this — no
+  popup, no provider link.)
 
 ### Basic Auth
 - Username + password in Authorization header

--- a/.claude/commands/create-module.md
+++ b/.claude/commands/create-module.md
@@ -127,13 +127,13 @@ Invoke @module-scaffolder. It will:
   - Stage only files inside `package/<vendor>/[<suite>/]<service>/` (plus `gate-stamp.json`)
   - **Never** `git add -A` or `git add .` from the repo root — would pick up unrelated changes
   - **Never** commit `node_modules/`, `dist/`, `generated/`, `hub-sdk/generated/`, `build/`, `npm-shrinkwrap.json`, secrets, or `.env`
-- **If OAuth `authorization_code` (`requiresPlatformOAuthRegistration`):** the module ships
-  OAuth-capable, but the Hub "Connect" button stays dark until a **ZeroBias insider** registers
-  the OAuth app + secret and links the `OAuthProvider`. Tell the user this explicitly and hand
-  them the ready-to-file registration-task body from
-  @.claude/skills/connection-profile/SKILL.md ("OAuth Click-to-Connect = Module Half + Platform
-  Half"), and note it in the PR body. Do NOT attempt the platform half here — it's not
-  authorable from the module repo.
+- **If OAuth `authorization_code` (`requiresPlatformOAuthRegistration`):** the module + the
+  `oauth` provider artifact + the `x-oauth-providers` link are all contributor content-as-code
+  (author/load them, even to your own org first). The Hub "Connect" button still stays dark until
+  the **one insider step** is done: registering the external OAuth app + storing client_id/secret
+  in AWS Secrets Manager (secrets can't be content). Tell the user this and hand them the
+  ready-to-file task body from @.claude/skills/connection-profile/SKILL.md ("OAuth
+  Click-to-Connect — 3 layers"), and note it in the PR body.
 
 ## Success Criteria
 

--- a/.claude/commands/create-module.md
+++ b/.claude/commands/create-module.md
@@ -78,7 +78,7 @@ Invoke @module-scaffolder. It will:
   - Replace `api.yml` stub: paths, operations, components, security schemes
   - If connector: replace `connectionProfile.yml` stub (extend `tokenProfile` / `oauthClientProfile` / etc. from `@zerobias-org/types-core`)
   - If token expiry tracking is needed: create `connectionState.yml` extending `baseConnectionState` (otherwise omit — design-phase decides)
-  - **If OAuth `authorization_code` (click-to-Connect):** extend `oauthTokenProfile` + create `connectionState.yml` extending `oauthTokenState`, and add `x-oauth-providers: [<oauthProviderCode>]` to the profile (from @credential-manager). This is a **3-layer capability** (module + oauth provider artifact + external app/secret) — see the "OAuth Click-to-Connect — 3 layers" section in @.claude/skills/connection-profile/SKILL.md. Carry `requiresPlatformOAuthRegistration` forward to Phase 6.
+  - **If OAuth `authorization_code` (click-to-Connect):** extend `oauthTokenProfile` + create `connectionState.yml` extending `oauthTokenState`, and add `x-oauth-providers: [<oauthProviderCode>]` to the profile (from @credential-manager). This is a **3-layer capability** (module + oauth provider artifact + external app/secret) — see the "OAuth Click-to-Connect — 3 layers" section in @.claude/skills/connection-profile/SKILL.md. **Detect whether the provider exists in `zerobias-org/oauth`** (`gh api repos/zerobias-org/oauth/contents/package`); if `requiresNewOAuthProvider`, author it with the provider recipe and plan a **separate content PR to `zerobias-org/oauth`** (contributor content, no gradle gate). Carry `requiresNewOAuthProvider` + `requiresPlatformOAuthRegistration` forward to Phase 6.
   - Check for optional connection params (region, environment, etc.)
 - Invoke @schema-specialist for complex resource schemas (`$ref` composition)
 - Invoke @api-reviewer to validate against api-spec rules
@@ -129,11 +129,15 @@ Invoke @module-scaffolder. It will:
   - **Never** commit `node_modules/`, `dist/`, `generated/`, `hub-sdk/generated/`, `build/`, `npm-shrinkwrap.json`, secrets, or `.env`
 - **If OAuth `authorization_code` (`requiresPlatformOAuthRegistration`):** the module + the
   `oauth` provider artifact + the `x-oauth-providers` link are all contributor content-as-code
-  (author/load them, even to your own org first). The Hub "Connect" button still stays dark until
-  the **one insider step** is done: registering the external OAuth app + storing client_id/secret
-  in AWS Secrets Manager (secrets can't be content). Tell the user this and hand them the
-  ready-to-file task body from @.claude/skills/connection-profile/SKILL.md ("OAuth
-  Click-to-Connect — 3 layers"), and note it in the PR body.
+  (author/load them, even to your own org first).
+  - **If `requiresNewOAuthProvider` (provider not in `zerobias-org/oauth`):** open a **second PR**
+    against `zerobias-org/oauth` adding the provider package (recipe in the skill) — this is an
+    explicit deliverable, not optional. The module can't advertise OAuth until that provider loads.
+  - The Hub "Connect" button still stays dark until the **one insider step** is done: registering
+    the external OAuth app + storing client_id/secret in AWS Secrets Manager (secrets can't be
+    content). Tell the user this and hand them the ready-to-file task body from
+    @.claude/skills/connection-profile/SKILL.md ("OAuth Click-to-Connect — 3 layers"), and note
+    both the oauth-repo PR (if any) and the insider task in the module PR body.
 
 ## Success Criteria
 

--- a/.claude/commands/create-module.md
+++ b/.claude/commands/create-module.md
@@ -78,6 +78,7 @@ Invoke @module-scaffolder. It will:
   - Replace `api.yml` stub: paths, operations, components, security schemes
   - If connector: replace `connectionProfile.yml` stub (extend `tokenProfile` / `oauthClientProfile` / etc. from `@zerobias-org/types-core`)
   - If token expiry tracking is needed: create `connectionState.yml` extending `baseConnectionState` (otherwise omit — design-phase decides)
+  - **If OAuth `authorization_code` (click-to-Connect):** extend `oauthTokenProfile` + create `connectionState.yml` extending `oauthTokenState`, and add `x-oauth-providers: [<oauthProviderCode>]` to the profile (from @credential-manager). This is a **two-half capability** — see the "OAuth Click-to-Connect = Module Half + Platform Half" section in @.claude/skills/connection-profile/SKILL.md. Carry `requiresPlatformOAuthRegistration` forward to Phase 6.
   - Check for optional connection params (region, environment, etc.)
 - Invoke @schema-specialist for complex resource schemas (`$ref` composition)
 - Invoke @api-reviewer to validate against api-spec rules
@@ -126,6 +127,13 @@ Invoke @module-scaffolder. It will:
   - Stage only files inside `package/<vendor>/[<suite>/]<service>/` (plus `gate-stamp.json`)
   - **Never** `git add -A` or `git add .` from the repo root — would pick up unrelated changes
   - **Never** commit `node_modules/`, `dist/`, `generated/`, `hub-sdk/generated/`, `build/`, `npm-shrinkwrap.json`, secrets, or `.env`
+- **If OAuth `authorization_code` (`requiresPlatformOAuthRegistration`):** the module ships
+  OAuth-capable, but the Hub "Connect" button stays dark until a **ZeroBias insider** registers
+  the OAuth app + secret and links the `OAuthProvider`. Tell the user this explicitly and hand
+  them the ready-to-file registration-task body from
+  @.claude/skills/connection-profile/SKILL.md ("OAuth Click-to-Connect = Module Half + Platform
+  Half"), and note it in the PR body. Do NOT attempt the platform half here — it's not
+  authorable from the module repo.
 
 ## Success Criteria
 

--- a/.claude/commands/create-module.md
+++ b/.claude/commands/create-module.md
@@ -78,7 +78,7 @@ Invoke @module-scaffolder. It will:
   - Replace `api.yml` stub: paths, operations, components, security schemes
   - If connector: replace `connectionProfile.yml` stub (extend `tokenProfile` / `oauthClientProfile` / etc. from `@zerobias-org/types-core`)
   - If token expiry tracking is needed: create `connectionState.yml` extending `baseConnectionState` (otherwise omit — design-phase decides)
-  - **If OAuth `authorization_code` (click-to-Connect):** extend `oauthTokenProfile` + create `connectionState.yml` extending `oauthTokenState`, and add `x-oauth-providers: [<oauthProviderCode>]` to the profile (from @credential-manager). This is a **two-half capability** — see the "OAuth Click-to-Connect = Module Half + Platform Half" section in @.claude/skills/connection-profile/SKILL.md. Carry `requiresPlatformOAuthRegistration` forward to Phase 6.
+  - **If OAuth `authorization_code` (click-to-Connect):** extend `oauthTokenProfile` + create `connectionState.yml` extending `oauthTokenState`, and add `x-oauth-providers: [<oauthProviderCode>]` to the profile (from @credential-manager). This is a **3-layer capability** (module + oauth provider artifact + external app/secret) — see the "OAuth Click-to-Connect — 3 layers" section in @.claude/skills/connection-profile/SKILL.md. Carry `requiresPlatformOAuthRegistration` forward to Phase 6.
   - Check for optional connection params (region, environment, etc.)
 - Invoke @schema-specialist for complex resource schemas (`$ref` composition)
 - Invoke @api-reviewer to validate against api-spec rules

--- a/.claude/skills/connection-profile/SKILL.md
+++ b/.claude/skills/connection-profile/SKILL.md
@@ -142,7 +142,7 @@ $ref: './node_modules/@zerobias-org/types-core/schema/oauthTokenProfile.yml'
 $ref: './node_modules/@zerobias-org/types-core/schema/oauthTokenState.yml'
 ```
 
-## 🚨 CRITICAL: OAuth "Click-to-Connect" — 3 layers, only 1 is insider
+## 🚨 CRITICAL: OAuth Click-to-Connect — 3 layers (only 1 is insider)
 
 **Choosing an OAuth `authorization_code` flow (the Hub "Connect" button) spans three layers, and
 two of the three are contributor-self-serve content-as-code:**
@@ -159,7 +159,9 @@ authorization-code is chosen, open a task for layer 3**.
 ### The module half — YOU author this (fully self-serve)
 
 **Copy a real shipped OAuth module rather than authoring from scratch.** Verified
-reference implementations in `@auditlogic/module-*` (all use `x-oauth-providers` + refresh):
+reference implementations in `@auditlogic/module-*` (all use `x-oauth-providers` + refresh). Note
+the `$ref` scope: current modules use `@zerobias-org/types-core`; older ones (e.g. `slack`) use
+`@auditmation/types-core` — same schemas, use `@zerobias-org/types-core` for new work:
 
 | Module | Provider | Good example of |
 |--------|----------|-----------------|
@@ -198,8 +200,16 @@ allOf:
         format: password
 ```
 
-> ⚠️ **Omitting `x-ui-hidden` leaks raw `accessToken`/`refreshToken` fields into the connect
-> form.** Every shipped OAuth module hides them — match that.
+> ⚠️ **`x-ui-*` = which fields the connect FORM shows.** Rule of thumb:
+> - `x-ui-hidden`: the OAuth-flow fields the user should never type — always hide `tokenType`,
+>   `refreshToken`, `expiresIn`, `scope`, `url`.
+> - `x-ui-required`: the fields that ARE the manual connect method. This is a **real design choice**,
+>   not fixed: `msgraph` requires the app creds (`clientId`/`clientSecret`/`directoryId`) and HIDES
+>   `accessToken`; `slack` instead REQUIRES `accessToken` (it supports pasting a bot token) and hides
+>   the rest. Pick per module: hide `accessToken` for pure click-to-connect; require it only if you
+>   also support manual token paste. (The "Build-Time Resolution → The Pattern" example lower in
+>   this file shows the require-`accessToken` variant — that's the slack-style choice, not a
+>   contradiction.)
 
 **connectionState.yml** — extend `oauthTokenState.yml` (accessToken + **refreshToken** +
 `expiresIn` in SECONDS + scope). It MUST resolve to `baseConnectionState` (which `oauthTokenState`
@@ -254,11 +264,39 @@ wasted effort. Your `connect()`/`refresh()` only:
 | **Authorize** URL | the `oauth` provider `index.yml` (`url`) | `login.microsoftonline.com/…/oauth2/v2.0/authorize` |
 | **Token** URL | **hardcoded constant in your client** — NOT the provider | `const BASE_TOKEN_URI + tenant + '/oauth2/v2.0/token'` |
 | **Scopes** | **hardcoded constant in your client** (api.yml securityScheme only *documents* them) | `const MS_GRAPH_SCOPE` |
-| `accessToken` / `refreshToken` | `connectionState` — handed to you at runtime | — |
+| `accessToken` / `refreshToken` | read them off **`connectionProfile`** at runtime (see note) | `this.connectionProfile.refreshToken` |
+
+> **`connect()` has no `connectionState` argument — the tokens arrive on `connectionProfile`.**
+> Because the profile `allOf`-includes `oauthTokenState`, `accessToken`/`refreshToken`/`expiresIn`
+> are fields *on the profile object* the Hub hands you. Real modules read
+> `this.connectionProfile.accessToken` / `.refreshToken` — do NOT look for a separate state param.
+> (`refresh()` does receive a `connectionState` arg for metadata, but the refresh token still comes
+> from the profile.)
 
 The provider artifact carries **only** the authorize URL + a UUID. The **token endpoint and scopes
 are yours to hardcode** in `connect()/refresh()` (they're universal per-provider constants — don't
 put them in the profile or provider).
+
+#### 🚨 Testing an OAuth module locally (there's no popup in a test run)
+
+Every `connectionProfile` field is supplied as a **zbb secret whose name matches the field name**;
+`describeModule<T>` injects them into the `ConnectionProfile` passed to `connect()` (non-secret test
+params go via `zbb env set` → `test/e2e/constants.ts`). The catch: **there's no OAuth popup in
+`testDirect`/`testDocker`**, so *something* has to supply a token. Two real paths:
+
+- **Dual-mode / app-creds (easiest — what makes `msgraph` testable):** if the module also supports a
+  manual `client_credentials` path, store `clientId`/`clientSecret`(+`directoryId`/tenant) as secrets;
+  `connect()` mints its own `accessToken` — no popup, no pre-minted token needed.
+  ```bash
+  zbb secret create clientId     --module @zerobias-org/module-<v>-<p> --slot local
+  zbb secret create clientSecret --module @zerobias-org/module-<v>-<p> --slot local
+  ```
+- **Pure click-to-connect only:** there's no way to mint a token locally — obtain a real
+  `accessToken`/`refreshToken` **once, out-of-band** (Postman/curl against the provider) and store them
+  as secrets so `connect()`/`refresh()` can run. Tests `this.skip()` gracefully when the values are
+  absent, so CI stays green without them.
+
+Reference e2e wiring: `msgraph`, `jira` (`test/e2e/` + `constants.ts`).
 
 The `<vendor>.oauth` code refers to an **`OAuthProvider` resource** in the `zerobias-org/oauth`
 repo. Reuse an existing provider when one fits (e.g. `microsoft` /
@@ -309,12 +347,17 @@ Decision:
 
 #### Recipe: add a missing provider (a `zerobias-org/oauth` content PR)
 
+> **Prerequisite:** the `dependencies` below reference `@zerobias-org/vendor-<vendor>` (or the
+> suite/product package). That **catalog content must already exist** — if the vendor/product isn't
+> in the catalog yet, create it FIRST via `/create-product`, then add the oauth provider. A provider
+> whose vendor dep doesn't resolve won't load.
+
 No scaffold script and **no gradle gate** — it's a 2-file Lerna package. Copy an existing
-`package/<vendor>/` and change 4 things:
+`package/<vendor>/` and change 4 things (generate the UUID with `uuidgen`):
 
 ```yaml
 # package/<vendor>/index.yml
-id: <fresh v4 UUID>                       # repo-wide unique, IMMUTABLE once published
+id: <fresh v4 UUID>                       # `uuidgen` — repo-wide unique, IMMUTABLE once published
 url: https://<provider>/oauth2/authorize  # the AUTHORIZE endpoint (not the token endpoint)
 ```
 ```jsonc
@@ -326,15 +369,16 @@ url: https://<provider>/oauth2/authorize  # the AUTHORIZE endpoint (not the toke
   "zerobias": {
     "package": "<vendor>.oauth",       // ← the code x-oauth-providers resolves against
     "import-artifact": "oauth",        // ← tells the dataloader the artifact type
-    "dataloader-version": "<current>"  // match the other packages in the repo
+    "dataloader-version": "<current>"  // copy from a sibling package's package.json
   },
-  "dependencies": { "@zerobias-org/vendor-<vendor>": "latest" }  // ← binds to the VSP
+  "dependencies": { "@zerobias-org/vendor-<vendor>": "latest" }  // ← binds to the VSP (must exist)
 }
 ```
 - **VSP scope** = whatever package you depend on: vendor-level → `@zerobias-org/vendor-<vendor>` +
   code `<vendor>.oauth`; suite/product-scoped → depend on that package + code
   `<vendor>.<suite>.<product>.oauth`, nested at `package/<vendor>/<suite>/…`.
 - Publishes via Lerna to GitHub npm, then loads via the dataloader (`import-artifact: oauth`).
+- **PR base is `main`** — the `zerobias-org/oauth` repo has no `dev` branch.
 
 ### The genuinely-insider half — external app + secret (a contributor CANNOT self-serve)
 

--- a/.claude/skills/connection-profile/SKILL.md
+++ b/.claude/skills/connection-profile/SKILL.md
@@ -142,12 +142,19 @@ $ref: './node_modules/@zerobias-org/types-core/schema/oauthTokenProfile.yml'
 $ref: './node_modules/@zerobias-org/types-core/schema/oauthTokenState.yml'
 ```
 
-## 🚨 CRITICAL: OAuth "Click-to-Connect" = Module Half + Platform Half
+## 🚨 CRITICAL: OAuth "Click-to-Connect" — 3 layers, only 1 is insider
 
-**Choosing an OAuth `authorization_code` flow (the Hub "Connect" button) is only HALF a
-self-serve task.** The module declares the capability; a **ZeroBias insider** must register
-the OAuth app and wire it to the platform before the Connect button does anything. If you
-ship the module half without opening the insider task, the button stays dark.
+**Choosing an OAuth `authorization_code` flow (the Hub "Connect" button) spans three layers, and
+two of the three are contributor-self-serve content-as-code:**
+
+1. **Module** — connectionProfile/state + `connect()/refresh()` (you author).
+2. **Provider wiring** — the `oauth` artifact (`index.yml {id,url}`) + the `x-oauth-providers`
+   link (you author + load as content — even to your own org first).
+3. **External app + secret** — register the OAuth app and put client_id/secret in AWS Secrets
+   Manager (**the only genuinely-insider step**; secrets can't be content).
+
+If you ship layers 1–2 but no one does layer 3, the button stays dark — so **when OAuth
+authorization-code is chosen, open a task for layer 3**.
 
 ### The module half — YOU author this (fully self-serve)
 
@@ -234,27 +241,51 @@ repo. Reuse an existing provider when one fits (e.g. `microsoft` /
 `login.microsoftonline.com/organizations/oauth2/v2.0/authorize` already exists — reuse it for
 any Entra/Azure AD-backed product) rather than inventing a new one.
 
-### The platform half — a ZeroBias INSIDER must do this (a contributor CANNOT self-serve)
+### The provider wiring — content-as-code YOU author + load (NOT insider)
 
-The client_id/secret live in AWS Secrets Manager, and the redirect URI is ZeroBias's shared
-Global App callback — none of this is authorable from the module repo. So **when OAuth
-authorization-code is chosen, tell the user to open a registration task** with this body:
+`oauth` is a **loadable artifact type** (see `.claude/docs/dataloader-artifact-map.md`), just
+like vendor/product/module. The provider lives in the **`zerobias-org/oauth`** repo as
+`@zerobias-org/oauth-<vendor>` and its only manifest is `index.yml`:
+
+```yaml
+# zerobias-org/oauth · package/<vendor>/index.yml  (nest package/<vendor>/<suite>/ for a suite)
+id: 9d975c18-45d4-4974-abcb-90aea1795c12          # stable UUID (repo-wide unique)
+url: https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize   # public authorize URL
+```
+
+**No client_id, no secret — just the public authorize URL + a UUID.** The package's `package.json`
+`zerobias` block deps on the vendor/suite/product package, which resolves the provider to a **VSP
+by package-code convention**. The module references it via `x-oauth-providers: [<vendor>.oauth]`;
+the two meet in `OAuthProvider` at dataload.
+
+So the provider **and** the module→provider link are authored and loaded **exactly like any other
+content** — you can even load them into your OWN org first (org-private) before PRing to the shared
+catalog. **Reuse an existing provider when one fits** — already present:
+`microsoft`, `github`, `atlassian`, `slack`, `zoho`, `google`. (e.g. reuse `oauth-microsoft` for
+any Entra/Azure AD product; only add a new `oauth-<vendor>` package if none matches.)
+
+### The genuinely-insider half — external app + secret (a contributor CANNOT self-serve)
+
+Only **two** things are NOT content-as-code, because they involve an external OAuth app and a
+secret. **When OAuth authorization-code is chosen, tell the user to open a task for JUST these:**
 
 ```
-Title: Register <vendor> OAuth app + link to <module-package> connectionProfile
+Title: Register <vendor> OAuth app + Secrets Manager entry for click-to-connect
 
-The <module-package> connector is OAuth-capable (authorization-code + refresh) but its
-"Connect" button won't work until the platform-side OAuth wiring exists:
+The <module-package> connector is OAuth-capable and its oauth provider artifact + connectionProfile
+link are authored/loaded as content. Two insider steps remain before the "Connect" button works:
   1. Register (or confirm) the <vendor> OAuth app with the provider → obtain client_id +
-     client_secret; confirm ZeroBias's Global App redirect URI is allow-listed and the
-     required scopes / admin-consent are granted.
-  2. Store client_id/client_secret in AWS Secrets Manager (dev + prod).
-  3. Load the OAuthProvider resource (zerobias-org/oauth) if it does not already exist,
-     and LINK it to the module's connectionProfile (referenced via x-oauth-providers:
-     [<vendor>.oauth]) so the Store advertises OAuth support.
+     client_secret; allow-list ZeroBias's shared Global App redirect URI; grant scopes/admin-consent.
+     (For a reused provider like Microsoft, the shared app may already exist.)
+  2. Store client_id/client_secret in AWS Secrets Manager (dev + prod), keyed to the
+     <vendor>.oauth OAuthProvider. Secrets cannot live in loadable content — this is the hard step.
 
 Outcome: OAuth-enabled <vendor> connections show the click-to-Connect button in Hub.
 ```
+
+> If the provider package doesn't exist yet, authoring it (`@zerobias-org/oauth-<vendor>`,
+> `index.yml {id,url}`) is **your** job, not the insider's — it's a normal content PR to
+> `zerobias-org/oauth`. The insider task is only the external app + the secret.
 
 > OAuth **client-credentials** (Pattern 2) is different: it needs no click-to-connect popup
 > and no provider link — the user supplies clientId/clientSecret directly. No insider task,

--- a/.claude/skills/connection-profile/SKILL.md
+++ b/.claude/skills/connection-profile/SKILL.md
@@ -142,6 +142,62 @@ $ref: './node_modules/@zerobias-org/types-core/schema/oauthTokenProfile.yml'
 $ref: './node_modules/@zerobias-org/types-core/schema/oauthTokenState.yml'
 ```
 
+## 🚨 CRITICAL: OAuth "Click-to-Connect" = Module Half + Platform Half
+
+**Choosing an OAuth `authorization_code` flow (the Hub "Connect" button) is only HALF a
+self-serve task.** The module declares the capability; a **ZeroBias insider** must register
+the OAuth app and wire it to the platform before the Connect button does anything. If you
+ship the module half without opening the insider task, the button stays dark.
+
+### The module half — YOU author this (fully self-serve)
+
+| File | What to author |
+|------|----------------|
+| `connectionProfile.yml` | Extend `oauthTokenProfile.yml` (clientId, clientSecret, url). Add the provider hook: `x-oauth-providers: [<vendor>.oauth]` — this is what makes the Hub UI offer the OAuth popup. |
+| `connectionState.yml` | Extend `oauthTokenState.yml` (accessToken, **refreshToken**, expiresIn in SECONDS, scope) — MUST extend `baseConnectionState` so the server schedules refresh. |
+| `src/<Class>Impl.ts` (`connect()`/`refresh()`) | Exchange/refresh tokens. Receive `clientId`/`clientSecret` at runtime via the `oauthDetails` argument — **never hardcode or persist them**. Validate `oauthDetails.clientId`, `.clientSecret`, `connectionProfile.refreshToken`; throw `InvalidCredentialsError` if missing. |
+
+```yaml
+# connectionProfile.yml — OAuth authorization-code, with the provider hook
+type: object
+allOf:
+  - $ref: './node_modules/@zerobias-org/types-core/schema/oauthTokenProfile.yml'
+  - type: object
+    x-oauth-providers:
+      - <vendor>.oauth        # e.g. microsoft.oauth for Entra-based products (Wiz, etc.)
+```
+
+The `<vendor>.oauth` code refers to an **`OAuthProvider` resource** in the `zerobias-org/oauth`
+repo. Reuse an existing provider when one fits (e.g. `microsoft` /
+`login.microsoftonline.com/organizations/oauth2/v2.0/authorize` already exists) rather than
+inventing a new one.
+
+### The platform half — a ZeroBias INSIDER must do this (a contributor CANNOT self-serve)
+
+The client_id/secret live in AWS Secrets Manager, and the redirect URI is ZeroBias's shared
+Global App callback — none of this is authorable from the module repo. So **when OAuth
+authorization-code is chosen, tell the user to open a registration task** with this body:
+
+```
+Title: Register <vendor> OAuth app + link to <module-package> connectionProfile
+
+The <module-package> connector is OAuth-capable (authorization-code + refresh) but its
+"Connect" button won't work until the platform-side OAuth wiring exists:
+  1. Register (or confirm) the <vendor> OAuth app with the provider → obtain client_id +
+     client_secret; confirm ZeroBias's Global App redirect URI is allow-listed and the
+     required scopes / admin-consent are granted.
+  2. Store client_id/client_secret in AWS Secrets Manager (dev + prod).
+  3. Load the OAuthProvider resource (zerobias-org/oauth) if it does not already exist,
+     and LINK it to the module's connectionProfile (referenced via x-oauth-providers:
+     [<vendor>.oauth]) so the Store advertises OAuth support.
+
+Outcome: OAuth-enabled <vendor> connections show the click-to-Connect button in Hub.
+```
+
+> OAuth **client-credentials** (Pattern 2) is different: it needs no click-to-connect popup
+> and no provider link — the user supplies clientId/clientSecret directly. No insider task.
+> The registration task is only for the **authorization_code** ("Connect" button) flow.
+
 ### Pattern 4: Custom Fields (Extend Core)
 
 ```yaml

--- a/.claude/skills/connection-profile/SKILL.md
+++ b/.claude/skills/connection-profile/SKILL.md
@@ -151,26 +151,88 @@ ship the module half without opening the insider task, the button stays dark.
 
 ### The module half — YOU author this (fully self-serve)
 
-| File | What to author |
-|------|----------------|
-| `connectionProfile.yml` | Extend `oauthTokenProfile.yml` (clientId, clientSecret, url). Add the provider hook: `x-oauth-providers: [<vendor>.oauth]` — this is what makes the Hub UI offer the OAuth popup. |
-| `connectionState.yml` | Extend `oauthTokenState.yml` (accessToken, **refreshToken**, expiresIn in SECONDS, scope) — MUST extend `baseConnectionState` so the server schedules refresh. |
-| `src/<Class>Impl.ts` (`connect()`/`refresh()`) | Exchange/refresh tokens. Receive `clientId`/`clientSecret` at runtime via the `oauthDetails` argument — **never hardcode or persist them**. Validate `oauthDetails.clientId`, `.clientSecret`, `connectionProfile.refreshToken`; throw `InvalidCredentialsError` if missing. |
+**Copy a real shipped OAuth module rather than authoring from scratch.** Verified
+reference implementations in `@auditlogic/module-*` (all use `x-oauth-providers` + refresh):
+
+| Module | Provider | Good example of |
+|--------|----------|-----------------|
+| `microsoft/azure/msgraph` | `microsoft.oauth` | **Entra/Azure AD** — the closest analog for Wiz; dual-mode (OAuth **or** manual clientId/secret/directoryId) |
+| `atlassian/cloud/jira` | `atlassian.oauth` | explicit `connectionMode: [manual, oauth]` enum + oauth `basePath` rewrite |
+| `slack/slack` | `slack.oauth` | minimal OAuth-only profile; `connect()` hard-requires `oauthConnectionDetails` |
+| `github/github` | `github.oauth` | OAuth + PAT fallback |
+
+**connectionProfile.yml** — extend BOTH `oauthTokenProfile` AND `oauthTokenState`, add the
+provider hook, and use `x-ui-*` to control the connect form (this is what every real module does):
 
 ```yaml
-# connectionProfile.yml — OAuth authorization-code, with the provider hook
+# connectionProfile.yml — OAuth authorization-code (mirrors msgraph/jira/slack)
 type: object
 allOf:
   - $ref: './node_modules/@zerobias-org/types-core/schema/oauthTokenProfile.yml'
+  - $ref: './node_modules/@zerobias-org/types-core/schema/oauthTokenState.yml'
   - type: object
     x-oauth-providers:
-      - <vendor>.oauth        # e.g. microsoft.oauth for Entra-based products (Wiz, etc.)
+      - <vendor>.oauth          # e.g. microsoft.oauth for Entra-based products (Wiz, etc.)
+    x-ui-required:              # fields the connect form REQUIRES (manual-entry / OAuth-app creds)
+      - clientId
+      - clientSecret
+    x-ui-hidden:               # HIDE the token-state fields the OAuth flow fills in for you
+      - tokenType
+      - accessToken
+      - refreshToken
+      - expiresIn
+      - scope
+      - url
+    properties:
+      clientId:
+        type: string
+      clientSecret:
+        type: string
+        format: password
 ```
+
+> ⚠️ **Omitting `x-ui-hidden` leaks raw `accessToken`/`refreshToken` fields into the connect
+> form.** Every shipped OAuth module hides them — match that.
+
+**connectionState.yml** — extend `oauthTokenState.yml` (accessToken + **refreshToken** +
+`expiresIn` in SECONDS + scope). It MUST resolve to `baseConnectionState` (which `oauthTokenState`
+already does) so the server schedules the refresh cronjob.
+
+**`src/<Class>Impl.ts` — `connect()` / `refresh()`.** The OAuth app creds arrive at runtime as
+a typed 2nd argument, `OauthConnectionDetails` (from `@zerobias-org/types-core-js`) — **never
+hardcode or persist them**. Real signature (from msgraph/github):
+
+```ts
+import { OauthConnectionDetails } from '@zerobias-org/types-core-js';
+
+async connect(
+  connectionProfile: ConnectionProfile,
+  oauthConnectionDetails?: OauthConnectionDetails,
+): Promise<BaseConnectionState> { /* exchange code/refresh → accessToken */ }
+
+async refresh(
+  connectionProfile: ConnectionProfile,
+  connectionState: BaseConnectionState,
+  oauthConnectionDetails?: OauthConnectionDetails,
+): Promise<BaseConnectionState> {
+  // canonical: delegate to connect() with refresh=true
+  return this.client.connect(connectionProfile, oauthConnectionDetails, true);
+}
+```
+
+Gotchas the real modules encode:
+- **Accept both casings.** The node→module boundary may deliver `clientId` OR `client_id`.
+  msgraph reads `oauth?.clientId ?? oauth?.client_id` — a forced refresh silently lost creds
+  until it handled both. Do the same for `clientSecret`/`client_secret`.
+- **Dual-mode fallback.** OAuth is not strictly either/or with token auth. msgraph/jira accept
+  the OAuth popup creds *or* fall back to `connectionProfile.clientId/clientSecret` for a manual
+  client-credentials connection. Throw `InvalidCredentialsError` (or a specific message naming
+  the missing field) only when neither path has what it needs.
 
 The `<vendor>.oauth` code refers to an **`OAuthProvider` resource** in the `zerobias-org/oauth`
 repo. Reuse an existing provider when one fits (e.g. `microsoft` /
-`login.microsoftonline.com/organizations/oauth2/v2.0/authorize` already exists) rather than
-inventing a new one.
+`login.microsoftonline.com/organizations/oauth2/v2.0/authorize` already exists — reuse it for
+Wiz/Entra) rather than inventing a new one.
 
 ### The platform half — a ZeroBias INSIDER must do this (a contributor CANNOT self-serve)
 

--- a/.claude/skills/connection-profile/SKILL.md
+++ b/.claude/skills/connection-profile/SKILL.md
@@ -236,6 +236,30 @@ Gotchas the real modules encode:
   client-credentials connection. Throw `InvalidCredentialsError` (or a specific message naming
   the missing field) only when neither path has what it needs.
 
+#### 🚨 What the module does — and does NOT — do at runtime
+
+The **platform's Global App** performs the authorization-code exchange (the popup, `code`,
+`redirect_uri`) and hands your module an **already-minted `accessToken` + `refreshToken`** in the
+connection state. So **do NOT implement a `code`→token exchange in the module** — that's a common
+wasted effort. Your `connect()`/`refresh()` only:
+- **`connect()` (normal OAuth):** just USE / validate the `accessToken` you were handed.
+- **`refresh()`:** re-mint the token yourself — `POST` to the token endpoint with
+  `grant_type: refresh_token`, `refresh_token` from the profile/state, and `client_id`/`client_secret`
+  from `OauthConnectionDetails`. (Only the *manual* dual-mode fallback uses `grant_type: client_credentials`.)
+
+#### 🚨 Where each URL / scope lives (non-obvious — get this right)
+
+| Thing | Lives in | Example (msgraph) |
+|-------|----------|-------------------|
+| **Authorize** URL | the `oauth` provider `index.yml` (`url`) | `login.microsoftonline.com/…/oauth2/v2.0/authorize` |
+| **Token** URL | **hardcoded constant in your client** — NOT the provider | `const BASE_TOKEN_URI + tenant + '/oauth2/v2.0/token'` |
+| **Scopes** | **hardcoded constant in your client** (api.yml securityScheme only *documents* them) | `const MS_GRAPH_SCOPE` |
+| `accessToken` / `refreshToken` | `connectionState` — handed to you at runtime | — |
+
+The provider artifact carries **only** the authorize URL + a UUID. The **token endpoint and scopes
+are yours to hardcode** in `connect()/refresh()` (they're universal per-provider constants — don't
+put them in the profile or provider).
+
 The `<vendor>.oauth` code refers to an **`OAuthProvider` resource** in the `zerobias-org/oauth`
 repo. Reuse an existing provider when one fits (e.g. `microsoft` /
 `login.microsoftonline.com/organizations/oauth2/v2.0/authorize` already exists — reuse it for
@@ -263,6 +287,35 @@ content** — you can even load them into your OWN org first (org-private) befor
 catalog. **Reuse an existing provider when one fits** — already present:
 `microsoft`, `github`, `atlassian`, `slack`, `zoho`, `google`. (e.g. reuse `oauth-microsoft` for
 any Entra/Azure AD product; only add a new `oauth-<vendor>` package if none matches.)
+
+#### Recipe: add a missing provider (a `zerobias-org/oauth` content PR)
+
+No scaffold script and **no gradle gate** — it's a 2-file Lerna package. Copy an existing
+`package/<vendor>/` and change 4 things:
+
+```yaml
+# package/<vendor>/index.yml
+id: <fresh v4 UUID>                       # repo-wide unique, IMMUTABLE once published
+url: https://<provider>/oauth2/authorize  # the AUTHORIZE endpoint (not the token endpoint)
+```
+```jsonc
+// package/<vendor>/package.json  (only the load-bearing keys shown)
+{
+  "name": "@zerobias-org/oauth-<vendor>",
+  "files": ["index.yml"],
+  "scripts": { "nx:publish": "../../scripts/publish.sh" },
+  "zerobias": {
+    "package": "<vendor>.oauth",       // ← the code x-oauth-providers resolves against
+    "import-artifact": "oauth",        // ← tells the dataloader the artifact type
+    "dataloader-version": "<current>"  // match the other packages in the repo
+  },
+  "dependencies": { "@zerobias-org/vendor-<vendor>": "latest" }  // ← binds to the VSP
+}
+```
+- **VSP scope** = whatever package you depend on: vendor-level → `@zerobias-org/vendor-<vendor>` +
+  code `<vendor>.oauth`; suite/product-scoped → depend on that package + code
+  `<vendor>.<suite>.<product>.oauth`, nested at `package/<vendor>/<suite>/…`.
+- Publishes via Lerna to GitHub npm, then loads via the dataloader (`import-artifact: oauth`).
 
 ### The genuinely-insider half — external app + secret (a contributor CANNOT self-serve)
 

--- a/.claude/skills/connection-profile/SKILL.md
+++ b/.claude/skills/connection-profile/SKILL.md
@@ -156,7 +156,7 @@ reference implementations in `@auditlogic/module-*` (all use `x-oauth-providers`
 
 | Module | Provider | Good example of |
 |--------|----------|-----------------|
-| `microsoft/azure/msgraph` | `microsoft.oauth` | **Entra/Azure AD** — the closest analog for Wiz; dual-mode (OAuth **or** manual clientId/secret/directoryId) |
+| `microsoft/azure/msgraph` | `microsoft.oauth` | **Entra/Azure AD** — reuse `microsoft.oauth` for any Entra-backed product; dual-mode (OAuth **or** manual clientId/secret/directoryId) |
 | `atlassian/cloud/jira` | `atlassian.oauth` | explicit `connectionMode: [manual, oauth]` enum + oauth `basePath` rewrite |
 | `slack/slack` | `slack.oauth` | minimal OAuth-only profile; `connect()` hard-requires `oauthConnectionDetails` |
 | `github/github` | `github.oauth` | OAuth + PAT fallback |
@@ -172,7 +172,7 @@ allOf:
   - $ref: './node_modules/@zerobias-org/types-core/schema/oauthTokenState.yml'
   - type: object
     x-oauth-providers:
-      - <vendor>.oauth          # e.g. microsoft.oauth for Entra-based products (Wiz, etc.)
+      - <vendor>.oauth          # e.g. microsoft.oauth for Entra/Azure AD-backed products
     x-ui-required:              # fields the connect form REQUIRES (manual-entry / OAuth-app creds)
       - clientId
       - clientSecret
@@ -232,7 +232,7 @@ Gotchas the real modules encode:
 The `<vendor>.oauth` code refers to an **`OAuthProvider` resource** in the `zerobias-org/oauth`
 repo. Reuse an existing provider when one fits (e.g. `microsoft` /
 `login.microsoftonline.com/organizations/oauth2/v2.0/authorize` already exists — reuse it for
-Wiz/Entra) rather than inventing a new one.
+any Entra/Azure AD-backed product) rather than inventing a new one.
 
 ### The platform half — a ZeroBias INSIDER must do this (a contributor CANNOT self-serve)
 
@@ -257,8 +257,13 @@ Outcome: OAuth-enabled <vendor> connections show the click-to-Connect button in 
 ```
 
 > OAuth **client-credentials** (Pattern 2) is different: it needs no click-to-connect popup
-> and no provider link — the user supplies clientId/clientSecret directly. No insider task.
-> The registration task is only for the **authorization_code** ("Connect" button) flow.
+> and no provider link — the user supplies clientId/clientSecret directly. No insider task,
+> fully contributor-self-serve. Extend `oauthClientProfile` (not `oauthTokenProfile`), and do
+> NOT add `x-oauth-providers`.
+> **Example: Wiz** — a Wiz *service account* (Settings → Service Accounts) yields a Client ID +
+> Client Secret exchanged via `client_credentials` at `auth.app.wiz.io/oauth/token`
+> (Auth0/Cognito, **not** Microsoft Entra). So a Wiz module is Pattern 2 end-to-end — no insider
+> task. The registration task is only for the **authorization_code** ("Connect" button) flow.
 
 ### Pattern 4: Custom Fields (Extend Core)
 

--- a/.claude/skills/connection-profile/SKILL.md
+++ b/.claude/skills/connection-profile/SKILL.md
@@ -407,10 +407,12 @@ Outcome: OAuth-enabled <vendor> connections show the click-to-Connect button in 
 > and no provider link — the user supplies clientId/clientSecret directly. No insider task,
 > fully contributor-self-serve. Extend `oauthClientProfile` (not `oauthTokenProfile`), and do
 > NOT add `x-oauth-providers`.
-> **Example: Wiz** — a Wiz *service account* (Settings → Service Accounts) yields a Client ID +
-> Client Secret exchanged via `client_credentials` at `auth.app.wiz.io/oauth/token`
-> (Auth0/Cognito, **not** Microsoft Entra). So a Wiz module is Pattern 2 end-to-end — no insider
-> task. The registration task is only for the **authorization_code** ("Connect" button) flow.
+> **Example (M2M / service account):** many products expose a *service account* (a Client ID +
+> Client Secret from their admin console) exchanged via `client_credentials` at the product's own
+> token endpoint — often an Auth0/Cognito-backed URL distinct from the vendor's user-SSO IdP. Don't
+> assume the token IdP from who owns the product; verify the actual token endpoint. Such a module is
+> Pattern 2 end-to-end — no insider task. The registration task is only for the
+> **authorization_code** ("Connect" button) flow.
 
 ### Pattern 4: Custom Fields (Extend Core)
 

--- a/.claude/skills/connection-profile/SKILL.md
+++ b/.claude/skills/connection-profile/SKILL.md
@@ -288,6 +288,25 @@ catalog. **Reuse an existing provider when one fits** — already present:
 `microsoft`, `github`, `atlassian`, `slack`, `zoho`, `google`. (e.g. reuse `oauth-microsoft` for
 any Entra/Azure AD product; only add a new `oauth-<vendor>` package if none matches.)
 
+#### 🚨 ALWAYS detect first — is the provider already in the repo?
+
+**Whenever a module needs an authorization-code provider, check the `oauth` repo live — do NOT
+trust the static list above (it drifts as providers are added).** Match your
+vendor (and suite/product, if the provider is scoped):
+
+```bash
+gh api repos/zerobias-org/oauth/contents/package --jq '.[].name'          # top-level vendors
+gh api repos/zerobias-org/oauth/git/trees/main:package?recursive=1 \
+  --jq '.tree[] | select(.path|endswith("index.yml")) | .path'            # every provider (incl. nested suite/product)
+```
+
+Decision:
+- **Provider exists** → reference it via `x-oauth-providers: [<code>]` and STOP. Nothing touches the oauth repo.
+- **Provider MISSING** → you must **add it** — author the package with the recipe below and open a
+  **separate content PR to `zerobias-org/oauth`** (contributor content, NOT the insider task).
+  Flag this as an extra deliverable so it isn't forgotten; the module can't advertise OAuth until
+  the provider is loaded.
+
 #### Recipe: add a missing provider (a `zerobias-org/oauth` content PR)
 
 No scaffold script and **no gradle gate** — it's a 2-file Lerna package. Copy an existing


### PR DESCRIPTION
## What

Makes OAuth `authorization_code` (the Hub "Connect" / click-to-authorize button) a first-class, explicitly-two-half capability in the create-module flow. Token-auth flows are untouched (92 additions, 0 deletions).

## Why

Choosing OAuth click-to-connect is only **half** a self-serve task. A contributor can author the module half, but the "Connect" button stays **dark** until a **ZeroBias insider** registers the OAuth app and wires it to the platform. Nothing in the workflow said so — so a contributor could ship an OAuth module that silently never connects.

## The split (now documented)

**Module half — contributor authors (self-serve):**
- `connectionProfile.yml` → extend `oauthTokenProfile.yml` + `x-oauth-providers: [<vendor>.oauth]` (the hook that lights up the Hub OAuth popup)
- `connectionState.yml` → extend `oauthTokenState.yml` (accessToken + refreshToken + `expiresIn` in seconds, via `baseConnectionState`)
- `connect()`/`refresh()` consuming `oauthDetails.clientId/clientSecret` at runtime (never persisted)

**Platform half — ZeroBias insider (NOT authorable from the module repo):**
- Register the OAuth app → client_id/secret; allow-list the shared Global App redirect URI; grant scopes/admin-consent
- Store client_id/secret in AWS Secrets Manager (dev + prod)
- Load the `OAuthProvider` resource (`zerobias-org/oauth`) and link it to the module's connectionProfile

## Changes

- **`.claude/skills/connection-profile/SKILL.md`** — new "OAuth Click-to-Connect = Module Half + Platform Half" section with a ready-to-file registration-task template (single source of truth). Notes that OAuth **client-credentials** needs no such task.
- **`.claude/agents/credential-manager.md`** — on OAuth authorization_code, flag `requiresPlatformOAuthRegistration: true` + `oauthProviderCode` (reuse e.g. `microsoft.oauth`), and surface the registration task to the user (not just `@api-architect`).
- **`.claude/commands/create-module.md`** — Phase 3 authors the OAuth profile/state + `x-oauth-providers`; Phase 6 hands the user the registration-task body and notes it in the PR.

Grounded in a zb-knowledge review of the Hub OAuth flow (`hub/docs/oauth.md`), the `oauth` provider registry, and the github/zoho module OAuth patterns.