### PR TITLE
fix(hl7-v2): group-preserving materializer + er7/validate ops

### DIFF
--- a/package/hl7/v2/gate-stamp.json
+++ b/package/hl7/v2/gate-stamp.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.2.2",
-  "branch": "hl7_multi_version",
+  "version": "1.2.2-uat.0",
+  "branch": "hl7_debug",
   "sourceHash": "c6a1fdddd55bed7060b65585b845626fcda7294a37ca3d34e90cea7e75b1a648",
   "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "tasks": {

--- a/package/hl7/v2/java/codegen/src/main/java/com/zerobias/module/hl7/codegen/SchemaGenerator.java
+++ b/package/hl7/v2/java/codegen/src/main/java/com/zerobias/module/hl7/codegen/SchemaGenerator.java
@@ -189,6 +189,9 @@ public final class SchemaGenerator {
         props.add(new Property("status", CoreTypes.STRING).required(true)
             .references(new Reference(STATUS_ENUM_ID)));
         props.add(new Property("leaseId", CoreTypes.STRING));
+        // Provenance overlaid by the producer (the many-named-ports model, §11.4); optional
+        // (null for pre-provenance rows). Declared so a served element validates clean.
+        props.add(new Property("sourcePort", CoreTypes.STRING));
         return props;
     }
 

--- a/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/buffer/BufferRow.java
+++ b/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/buffer/BufferRow.java
@@ -59,4 +59,15 @@ public record BufferRow(
             sendingApp, sendingFacility, hl7Version, schemaId, rawEr7, mappedJson,
             status, leaseId, inFlightUntil, ackedAt, null);
     }
+
+    /**
+     * A copy with a re-derived mapping ({@code schemaId} + {@code mappedJson}), every
+     * other field (raw ER7, envelope, lease) unchanged. Lets {@code ops/validate}
+     * element-ize a re-materialized rep through the same mapper as the stored rep.
+     */
+    public BufferRow withMapping(String newSchemaId, String newMappedJson) {
+        return new BufferRow(id, receivedAt, controlId, messageStructure, messageCode, triggerEvent,
+            sendingApp, sendingFacility, hl7Version, newSchemaId, rawEr7, newMappedJson,
+            status, leaseId, inFlightUntil, ackedAt, sourcePort);
+    }
 }

--- a/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/materializer/Materializer.java
+++ b/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/materializer/Materializer.java
@@ -13,7 +13,6 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -34,9 +33,12 @@ import java.util.Set;
  * the buffer envelope ({@code controlId}/{@code receivedAt}/{@code status}/
  * {@code leaseId}) is overlaid later from the authoritative buffer columns.
  *
- * <p>v1 scope: group nesting is flattened — a message's segments are keyed at the
- * top level by segment code (repeating segments/segments in repeating groups
- * become arrays). The per-segment field/component graph is fully materialized.
+ * <p>Group nesting is preserved: the walk consumes the message's document-ordered
+ * segment stream against the structure grammar, emitting nested group objects
+ * (e.g. {@code patient_result -> patient / order_observation}) so group membership
+ * — which OBX belongs to which OBR — survives, and every repeat is captured even
+ * when HAPI's generic parse splits a non-contiguous repeat into a numeric-suffixed
+ * slot ({@code OBX2}). The per-segment field/component graph is fully materialized.
  */
 public final class Materializer implements MessageMaterializer {
 
@@ -60,74 +62,147 @@ public final class Materializer implements MessageMaterializer {
 
     @Override
     public String toTypedJson(Message message) throws HL7Exception {
-        Map<String, Object> out = new LinkedHashMap<>();
-        for (SegmentSlot slot : segmentSlots(message)) {
-            List<Object> occurrences = new ArrayList<>();
-            for (Segment seg : segmentsNamed(message, slot.code)) {
-                Object obj = materializeSegment(seg, index.segment(slot.code));
-                if (obj != ABSENT) {
-                    occurrences.add(obj);
-                }
-            }
-            if (occurrences.isEmpty()) {
-                continue;
-            }
-            out.put(slot.name, (slot.multi || occurrences.size() > 1) ? occurrences : occurrences.get(0));
-        }
-        return GSON.toJson(out);
-    }
-
-    // --- which segments, in what order, with what cardinality --------------
-
-    private record SegmentSlot(String code, String name, boolean multi) {
-    }
-
-    /**
-     * The ordered, de-duplicated segment slots to emit. Driven by the message's
-     * structure entry when known (flattening groups, preserving order and OR-ing
-     * multi); otherwise falls back to the segments actually present (occurrence
-     * count decides array-ness).
-     */
-    private List<SegmentSlot> segmentSlots(Message message) throws HL7Exception {
+        List<Seg> stream = segmentStream(message);
         String structure = messageStructure(message);
         StructureIndex.MessageEntry entry = structure == null ? null : index.message(structure);
 
-        Map<String, SegmentSlot> slots = new LinkedHashMap<>();
+        Map<String, Object> out;
+        int[] cursor = {0};
         if (entry != null) {
-            collectSlots(entry, false, slots, new LinkedHashSet<>());
+            out = consume(entry, stream, cursor, new LinkedHashSet<>());
+        } else {
+            out = new LinkedHashMap<>();
         }
-        if (slots.isEmpty()) {
-            // unknown structure (or empty entry): emit every present segment we can name
-            for (String code : message.getNames()) {
-                if (index.segment(code) != null && !slots.containsKey(code)) {
-                    slots.put(code, new SegmentSlot(code, lower(code), false));
-                }
-            }
-        }
-        return new ArrayList<>(slots.values());
+        // Any segments the grammar didn't place (unknown structure, unexpected order,
+        // trailing Z-segments) are still emitted by code so nothing is dropped.
+        appendLeftover(out, stream, cursor[0]);
+        return GSON.toJson(out);
     }
 
-    /** Flatten a message/group entry into segment slots, descending nested groups. */
-    private void collectSlots(StructureIndex.MessageEntry entry, boolean inheritedMulti,
-            Map<String, SegmentSlot> slots, Set<String> visitingGroups) {
-        for (StructureIndex.StructureRef ref : entry.structures) {
-            boolean multi = inheritedMulti || ref.multi;
-            if (ref.group) {
-                if (visitingGroups.add(ref.structure)) {           // cycle-safe
-                    StructureIndex.MessageEntry g = index.groups.get(ref.structure);
-                    if (g != null) {
-                        collectSlots(g, multi, slots, visitingGroups);
-                    }
-                    visitingGroups.remove(ref.structure);
-                }
-            } else {
-                SegmentSlot existing = slots.get(ref.structure);
-                if (existing == null) {
-                    slots.put(ref.structure, new SegmentSlot(ref.structure, ref.name, multi));
-                } else if (multi && !existing.multi()) {
-                    slots.put(ref.structure, new SegmentSlot(ref.structure, existing.name(), true));
+    // --- document-ordered segment stream -----------------------------------
+
+    /** A parsed segment plus its true HL7 code (HAPI suffixes non-contiguous repeats: {@code OBX2}). */
+    private record Seg(String code, Segment segment) {
+    }
+
+    /**
+     * The message's segments in document order, every occurrence included. HAPI's
+     * generic parse gives a repeated segment that is interrupted by another segment
+     * its own numeric-suffixed slot ({@code OBX2}); we recover the real code and keep
+     * the occurrence, so no repeat is lost and group boundaries stay reconstructable.
+     * Each slot's reps are themselves contiguous, so flattening
+     * {@code getNames() × getAll()} reproduces true document order.
+     *
+     * <p>HL7 segment IDs are always exactly three characters and HAPI appends its
+     * rep-suffix <em>after</em> the code, so the real code is the first three chars —
+     * NOT the name with trailing digits stripped (that would mangle legitimate codes
+     * ending in a digit, e.g. {@code PV1}, {@code PV2}, {@code OM1}).
+     */
+    private List<Seg> segmentStream(Message message) throws HL7Exception {
+        List<Seg> stream = new ArrayList<>();
+        for (String name : message.getNames()) {
+            String code = name.length() > 3 ? name.substring(0, 3) : name;
+            for (Structure s : message.getAll(name)) {
+                if (s instanceof Segment) {
+                    stream.add(new Seg(code, (Segment) s));
                 }
             }
+        }
+        return stream;
+    }
+
+    // --- grammar-driven group assembly -------------------------------------
+
+    /**
+     * Consume the ordered segment stream against a message/group entry, emitting
+     * nested group objects (DESIGN §5). A segment ref consumes leading occurrences of
+     * its code up to cardinality; a group ref consumes as many group instances as
+     * begin at the cursor (decided by the group's FIRST-set), each a nested object.
+     * {@code cursor[0]} advances as segments are consumed. Preserves group membership
+     * and every repeat.
+     */
+    private Map<String, Object> consume(StructureIndex.MessageEntry entry, List<Seg> stream,
+            int[] cursor, Set<String> visiting) throws HL7Exception {
+        Map<String, Object> obj = new LinkedHashMap<>();
+        for (StructureIndex.StructureRef ref : entry.structures) {
+            if (ref.group) {
+                StructureIndex.MessageEntry g = index.groups.get(ref.structure);
+                if (g == null || !visiting.add(ref.structure)) {
+                    continue;   // missing definition or cyclic grammar — skip safely
+                }
+                List<Object> instances = new ArrayList<>();
+                while (cursor[0] < stream.size()
+                        && groupStarts(g, stream.get(cursor[0]).code(), new LinkedHashSet<>())) {
+                    int before = cursor[0];
+                    Map<String, Object> inst = consume(g, stream, cursor, visiting);
+                    if (cursor[0] == before) {
+                        break;   // consumed nothing this pass — don't spin
+                    }
+                    if (!inst.isEmpty()) {
+                        instances.add(inst);
+                    }
+                    if (!ref.multi) {
+                        break;
+                    }
+                }
+                visiting.remove(ref.structure);
+                if (!instances.isEmpty()) {
+                    obj.put(ref.name, ref.multi ? instances : instances.get(0));
+                }
+            } else {
+                List<Object> occ = new ArrayList<>();
+                while (cursor[0] < stream.size() && stream.get(cursor[0]).code().equals(ref.structure)) {
+                    Object v = materializeSegment(stream.get(cursor[0]).segment(), index.segment(ref.structure));
+                    cursor[0]++;
+                    if (v != ABSENT) {
+                        occ.add(v);
+                    }
+                    if (!ref.multi) {
+                        break;
+                    }
+                }
+                if (!occ.isEmpty()) {
+                    obj.put(ref.name, (ref.multi || occ.size() > 1) ? occ : occ.get(0));
+                }
+            }
+        }
+        return obj;
+    }
+
+    /**
+     * Whether {@code code} may legally begin {@code entry} — its FIRST-set: leading
+     * segment codes, descending into leading groups, stopping at the first required
+     * element (nothing after a required element can be the entry's start).
+     */
+    private boolean groupStarts(StructureIndex.MessageEntry entry, String code, Set<String> visiting) {
+        for (StructureIndex.StructureRef ref : entry.structures) {
+            if (ref.group) {
+                StructureIndex.MessageEntry g = index.groups.get(ref.structure);
+                if (g != null && visiting.add(ref.structure) && groupStarts(g, code, visiting)) {
+                    return true;
+                }
+            } else if (ref.structure.equals(code)) {
+                return true;
+            }
+            if (ref.required) {
+                return false;
+            }
+        }
+        return false;
+    }
+
+    /** Emit not-yet-consumed segments by code (arrays for repeats), without clobbering placed keys. */
+    private void appendLeftover(Map<String, Object> out, List<Seg> stream, int from) throws HL7Exception {
+        Map<String, List<Object>> byCode = new LinkedHashMap<>();
+        for (int i = from; i < stream.size(); i++) {
+            Seg s = stream.get(i);
+            Object v = materializeSegment(s.segment(), index.segment(s.code()));
+            if (v != ABSENT) {
+                byCode.computeIfAbsent(lower(s.code()), k -> new ArrayList<>()).add(v);
+            }
+        }
+        for (Map.Entry<String, List<Object>> e : byCode.entrySet()) {
+            out.putIfAbsent(e.getKey(), e.getValue().size() == 1 ? e.getValue().get(0) : e.getValue());
         }
     }
 
@@ -145,19 +220,6 @@ public final class Materializer implements MessageMaterializer {
             : (code != null && !code.isEmpty() && trigger != null && !trigger.isEmpty())
                 ? code + "_" + trigger : null;
         return resolver.resolve(code, t.get("/MSH-3"), base);
-    }
-
-    private List<Segment> segmentsNamed(Message message, String code) throws HL7Exception {
-        if (!Arrays.asList(message.getNames()).contains(code)) {
-            return List.of();
-        }
-        List<Segment> out = new ArrayList<>();
-        for (Structure s : message.getAll(code)) {
-            if (s instanceof Segment) {
-                out.add((Segment) s);
-            }
-        }
-        return out;
     }
 
     // --- segment / field / component walk ----------------------------------

--- a/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/producer/Hl7Operations.java
+++ b/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/producer/Hl7Operations.java
@@ -5,6 +5,7 @@ import com.zerobias.module.hl7.buffer.BufferStore;
 import com.zerobias.module.hl7.buffer.Lease;
 import com.zerobias.module.hl7.filter.Hl7Filter;
 
+import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.time.Duration;
 import java.time.format.DateTimeParseException;
@@ -54,18 +55,26 @@ public final class Hl7Operations {
 
     private final BufferStore buffer;
     private final Function<BufferRow, Map<String, Object>> elementMapper;
-    /** Re-materializes rows from raw ER7 for {@code recast}; null when unconfigured (back-compat). */
+    /** Re-materializes rows from raw ER7 for {@code recast}/{@code validate}; null when unconfigured. */
     private final Recaster recaster;
+    /** Validates a rep against its registered schema for {@code validate}; null when unconfigured. */
+    private final SchemaValidator validator;
 
     public Hl7Operations(BufferStore buffer, Function<BufferRow, Map<String, Object>> elementMapper) {
-        this(buffer, elementMapper, null);
+        this(buffer, elementMapper, null, null);
     }
 
     public Hl7Operations(BufferStore buffer, Function<BufferRow, Map<String, Object>> elementMapper,
             Recaster recaster) {
+        this(buffer, elementMapper, recaster, null);
+    }
+
+    public Hl7Operations(BufferStore buffer, Function<BufferRow, Map<String, Object>> elementMapper,
+            Recaster recaster, SchemaValidator validator) {
         this.buffer = buffer;
         this.elementMapper = elementMapper;
         this.recaster = recaster;
+        this.validator = validator;
     }
 
     /** Dispatch a {@code /hl7-v2-receiver/ops/<fn>} invocation. */
@@ -83,9 +92,105 @@ public final class Hl7Operations {
                 return recast(input);
             case "purge":
                 return purge(input);
+            case "er7":
+                return er7(input);
+            case "validate":
+                return validate(input);
             default:
                 throw ProducerException.noSuchObject("/hl7-v2-receiver/ops/" + fn);
         }
+    }
+
+    /**
+     * Return the canonical raw ER7 for one buffered message, addressed by its message id
+     * (MSH-10 / the DataProducer {@code elementKey}). This is the pre-JSON, pre-slot
+     * source of truth (audit / independent re-parse), verbatim as stored ({@code encode()}
+     * preserves original segment order). 404s when the id isn't buffered.
+     */
+    private Map<String, Object> er7(Map<String, Object> input) throws SQLException {
+        BufferRow row = requireRow(input);
+        Map<String, Object> out = new LinkedHashMap<>();
+        out.put("controlId", row.controlId());
+        out.put("hl7Version", row.hl7Version());
+        out.put("messageStructure", row.messageStructure());
+        out.put("sourcePort", row.sourcePort());
+        out.put("er7", row.rawEr7() == null ? null : new String(row.rawEr7(), StandardCharsets.UTF_8));
+        return out;
+    }
+
+    /**
+     * Validate one buffered message (by message id) against its registered schema, checking
+     * <em>both representations</em>: the {@code stored} typed JSON as served, and the
+     * {@code rematerialized} form re-derived from the row's raw ER7 through the current
+     * materializer. Each verdict is {@code {valid, errors[]}}; {@code repsAgree} is true when
+     * re-materialization reproduces the stored mapping. Lets an operator confirm a row
+     * conforms, and tells apart a stale row (stored fails, rematerialized passes → recast
+     * would repair) from a current-code defect (both fail).
+     */
+    private Map<String, Object> validate(Map<String, Object> input) throws SQLException {
+        if (validator == null) {
+            throw ProducerException.unsupported("validate is unavailable: no schema registry configured");
+        }
+        BufferRow row = requireRow(input);
+        Map<String, Object> out = new LinkedHashMap<>();
+        out.put("controlId", row.controlId());
+        out.put("schemaId", row.schemaId());
+        out.put("stored", verdict(elementMapper.apply(row), row.schemaId()));
+        if (recaster != null) {
+            try {
+                Recaster.Mapping m = recaster.rematerialize(row);
+                Map<String, Object> rv = verdict(elementMapper.apply(row.withMapping(m.schemaId(), m.mappedJson())),
+                    m.schemaId());
+                rv.put("schemaId", m.schemaId());
+                out.put("rematerialized", rv);
+                out.put("repsAgree",
+                    m.mappedJson().equals(row.mappedJson()) && m.schemaId().equals(row.schemaId()));
+            } catch (Exception e) {
+                out.put("rematerialized", Map.of("error", "re-materialization failed: " + e.getMessage()));
+                out.put("repsAgree", false);
+            }
+        }
+        return out;
+    }
+
+    private Map<String, Object> verdict(Map<String, Object> element, String schemaId) {
+        List<String> errors = validator.validate(element, schemaId);
+        Map<String, Object> v = new LinkedHashMap<>();
+        v.put("valid", errors.isEmpty());
+        v.put("errors", errors);
+        return v;
+    }
+
+    /**
+     * The single buffered row for a message id, from {@code elementKey} (the DataProducer
+     * key; {@code messageId}/{@code controlId} accepted as aliases). {@code control_id} is
+     * the buffer's global key, so no collection {@code objectId} scope is needed to locate
+     * it. Throws {@code noSuchObjectError} when unbuffered.
+     */
+    private BufferRow requireRow(Map<String, Object> input) throws SQLException {
+        String id = firstNonBlank(strArg(input, "elementKey"), strArg(input, "messageId"),
+            strArg(input, "controlId"));
+        if (id == null) {
+            throw ProducerException.illegalArgument("message id is required (elementKey / messageId / controlId)");
+        }
+        List<BufferRow> rows = buffer.search("control_id = " + sql(id), 1, 0);
+        if (rows.isEmpty()) {
+            throw ProducerException.noSuchObject("/hl7-v2-receiver message " + id);
+        }
+        return rows.get(0);
+    }
+
+    private static String firstNonBlank(String... vals) {
+        for (String v : vals) {
+            if (v != null && !v.isBlank()) {
+                return v;
+            }
+        }
+        return null;
+    }
+
+    private static String sql(String value) {
+        return "'" + value.replace("'", "''") + "'";
     }
 
     private Map<String, Object> take(Map<String, Object> input) throws SQLException {

--- a/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/producer/Hl7ProducerFacade.java
+++ b/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/producer/Hl7ProducerFacade.java
@@ -45,7 +45,7 @@ public final class Hl7ProducerFacade {
         this.buffer = buffer;
         this.tree = tree;
         this.schemas = schemas;
-        this.ops = new Hl7Operations(buffer, this::toElement, recaster);
+        this.ops = new Hl7Operations(buffer, this::toElement, recaster, new SchemaValidator(schemas));
         Hl7Filter.register();
     }
 

--- a/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/producer/ObjectTree.java
+++ b/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/producer/ObjectTree.java
@@ -59,7 +59,7 @@ public final class ObjectTree {
 
     static final String ENVELOPE_SCHEMA = "schema:shared:hl7v2.message-envelope";
     static final List<String> OPS_FUNCTIONS =
-        List.of("take", "ack", "release", "replay", "recast", "purge");
+        List.of("take", "ack", "release", "replay", "recast", "purge", "er7", "validate");
 
     private final BufferStore buffer;
     private final SchemaRegistry schemas;
@@ -393,6 +393,10 @@ public final class ObjectTree {
             case "ack":
             case "release":
                 t.put("lease_expired", "schema:shared:hl7v2.ops-error");
+                t.put("not_found", "schema:shared:hl7v2.ops-error");
+                break;
+            case "er7":
+            case "validate":
                 t.put("not_found", "schema:shared:hl7v2.ops-error");
                 break;
             default:

--- a/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/producer/Recaster.java
+++ b/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/producer/Recaster.java
@@ -62,13 +62,24 @@ public final class Recaster {
      * serialize here (an admin op, not a hot path).
      */
     public synchronized Optional<Mapping> recast(BufferRow row) throws HL7Exception {
+        Mapping m = rematerialize(row);
+        if (m.mappedJson().equals(row.mappedJson()) && m.schemaId().equals(row.schemaId())) {
+            return Optional.empty();
+        }
+        return Optional.of(m);
+    }
+
+    /**
+     * Re-materialize {@code row} from its raw ER7 under the current registry, routing by
+     * the row's stored version — <em>always</em> returning the mapping (unlike
+     * {@link #recast}, which returns empty when it reproduces the stored value). This is
+     * the re-materialized rep {@code ops/validate} checks against its schema.
+     */
+    public synchronized Mapping rematerialize(BufferRow row) throws HL7Exception {
         Message message = parser.parse(new String(row.rawEr7(), StandardCharsets.UTF_8));
         String version = row.hl7Version();
         String schemaId = materializers.schemaIdFor(version, row.messageStructure());
         String mappedJson = materializers.materializerFor(version).toTypedJson(message);
-        if (mappedJson.equals(row.mappedJson()) && schemaId.equals(row.schemaId())) {
-            return Optional.empty();
-        }
-        return Optional.of(new Mapping(schemaId, mappedJson));
+        return new Mapping(schemaId, mappedJson);
     }
 }

--- a/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/producer/SchemaValidator.java
+++ b/package/hl7/v2/java/src/main/java/com/zerobias/module/hl7/producer/SchemaValidator.java
@@ -1,0 +1,135 @@
+package com.zerobias.module.hl7.producer;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Validates a materialized element against its registered table schema (DESIGN §2.2/§2.3),
+ * resolving referenced group / segment / datatype schemas recursively through the
+ * {@link SchemaRegistry} (every non-leaf property references a {@code schema:type:} id, so
+ * groups, segments, and composite datatypes all recurse the same way).
+ *
+ * <p>Reports <em>structural</em> conformance problems as a flat list of dot-path messages:
+ * a missing required property, a single value where the schema declares a repeating
+ * (array) property, a scalar where an object is expected, and undeclared properties. Leaf
+ * values — plain scalars and {@code schema:enum:} codes — are accepted without deep
+ * type-checking: HL7's primitive/composite ambiguities (an under-delimited composite, an
+ * SI rendered as a string) would otherwise raise false positives, and it is the
+ * <em>shape</em> (grouping, cardinality, presence) that this op exists to police.
+ */
+public final class SchemaValidator {
+
+    private static final Gson GSON = new Gson();
+
+    private final SchemaRegistry schemas;
+
+    public SchemaValidator(SchemaRegistry schemas) {
+        this.schemas = schemas;
+    }
+
+    /** Conformance errors for {@code element} against {@code schemaId}; empty list = valid. */
+    public List<String> validate(Map<String, Object> element, String schemaId) {
+        List<String> errors = new ArrayList<>();
+        validateObject(element, schemaId, "", errors, new LinkedHashSet<>());
+        return errors;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void validateObject(Object value, String schemaId, String path,
+            List<String> errors, Set<String> visiting) {
+        if (!(value instanceof Map)) {
+            errors.add(at(path) + ": expected object (" + schemaId + ")");
+            return;
+        }
+        if (!visiting.add(schemaId)) {
+            return;   // cyclic schema graph — stop descending
+        }
+        try {
+            JsonObject schema = schema(schemaId);
+            if (schema == null || !schema.has("properties")) {
+                return;   // unknown/opaque schema — can't check, don't invent errors
+            }
+            Map<String, Object> obj = (Map<String, Object>) value;
+            Set<String> declared = new LinkedHashSet<>();
+            for (JsonElement pe : schema.getAsJsonArray("properties")) {
+                JsonObject p = pe.getAsJsonObject();
+                String name = p.get("name").getAsString();
+                declared.add(name);
+                validateProperty(obj, name, p, path, errors, visiting);
+            }
+            for (String key : obj.keySet()) {
+                if (!declared.contains(key)) {
+                    errors.add(at(child(path, key)) + ": undeclared property");
+                }
+            }
+        } finally {
+            visiting.remove(schemaId);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void validateProperty(Map<String, Object> obj, String name, JsonObject p,
+            String path, List<String> errors, Set<String> visiting) {
+        boolean required = p.has("required") && p.get("required").getAsBoolean();
+        boolean multi = p.has("multi") && p.get("multi").getAsBoolean();
+        String ref = refOf(p);
+        String cpath = child(path, name);
+
+        if (!obj.containsKey(name)) {
+            if (required) {
+                errors.add(at(cpath) + ": missing required property");
+            }
+            return;
+        }
+        Object v = obj.get(name);
+        if (v == null) {
+            return;   // explicit HL7 null — present, accept
+        }
+        boolean recurse = ref != null && ref.startsWith("schema:type:");
+        if (multi) {
+            if (!(v instanceof List)) {
+                errors.add(at(cpath) + ": expected array (repeating property)");
+            } else if (recurse) {
+                List<Object> list = (List<Object>) v;
+                for (int i = 0; i < list.size(); i++) {
+                    validateObject(list.get(i), ref, cpath + "[" + i + "]", errors, visiting);
+                }
+            }
+        } else if (recurse) {
+            validateObject(v, ref, cpath, errors, visiting);
+        }
+    }
+
+    private static String refOf(JsonObject p) {
+        if (p.has("references") && p.get("references").isJsonObject()) {
+            JsonObject r = p.getAsJsonObject("references");
+            if (r.has("schemaId")) {
+                return r.get("schemaId").getAsString();
+            }
+        }
+        return null;
+    }
+
+    private JsonObject schema(String schemaId) {
+        try {
+            return GSON.fromJson(schemas.getSchema(schemaId), JsonObject.class);
+        } catch (RuntimeException e) {
+            return null;   // not served (e.g. an enum stub) — treat as opaque leaf
+        }
+    }
+
+    private static String child(String path, String name) {
+        return path.isEmpty() ? name : path + "." + name;
+    }
+
+    private static String at(String path) {
+        return path.isEmpty() ? "<root>" : path;
+    }
+}

--- a/package/hl7/v2/java/src/test/java/com/zerobias/module/hl7/materializer/MaterializerIT.java
+++ b/package/hl7/v2/java/src/test/java/com/zerobias/module/hl7/materializer/MaterializerIT.java
@@ -105,7 +105,7 @@ class MaterializerIT {
     }
 
     @Test
-    void oruRoundTripsWithRepeatingObx() throws Exception {
+    void oruPreservesGroupNesting() throws Exception {
         Materializer m = materializer();
         String er7 = String.join(CR,
             "MSH|^~\\&|LAB|HOSP|RECV|DEST|20260529103000||ORU^R01^ORU_R01|MSG2|P|2.7",
@@ -116,16 +116,36 @@ class MaterializerIT {
 
         JsonObject root = GSON.fromJson(m.toTypedJson(parseGeneric(er7)), JsonObject.class);
 
-        assertTrue(root.has("pid"), "pid present");
-        assertTrue(root.has("obr"), "obr present");
-        // two OBX → array (repeating segment, flattened from its group)
-        JsonArray obx = root.getAsJsonArray("obx");
-        assertEquals(2, obx.size());
-        assertEquals("7.2", obx.get(0).getAsJsonObject().getAsJsonArray("observationValue").get(0).getAsString());
-        // PID sits in a repeating group in ORU_R01 → flattened as an array
-        assertEquals("DOE", root.getAsJsonArray("pid").get(0).getAsJsonObject()
-            .getAsJsonArray("patientName").get(0).getAsJsonObject()
+        // Group nesting is preserved (DESIGN §5): ORU_R01 = MSH + PATIENT_RESULT[
+        //   PATIENT{pid…}, ORDER_OBSERVATION[{obr, OBSERVATION[{obx}]}] ]. Segments are
+        // NOT hoisted to the top level — which OBX belongs to which order survives.
+        assertTrue(root.has("msh"), "msh at message level");
+        assertTrue(!root.has("pid") && !root.has("obx") && !root.has("obr"),
+            "segments are nested under their groups, not top-level: " + root.keySet());
+
+        JsonArray patientResult = root.getAsJsonArray("patient_result");
+        assertEquals(1, patientResult.size());
+        JsonObject pr = patientResult.get(0).getAsJsonObject();
+
+        // PID inside PATIENT — a single object (its own ref is non-repeating), even though
+        // PATIENT_RESULT itself repeats.
+        JsonObject pid = pr.getAsJsonObject("patient").getAsJsonObject("pid");
+        assertEquals("DOE", pid.getAsJsonArray("patientName").get(0).getAsJsonObject()
             .getAsJsonObject("familyName").get("surname").getAsString());
+
+        // One order; its two results nested as OBSERVATION instances beneath it.
+        JsonArray orders = pr.getAsJsonArray("order_observation");
+        assertEquals(1, orders.size());
+        JsonObject order = orders.get(0).getAsJsonObject();
+        assertEquals("CBC", order.getAsJsonObject("obr")
+            .getAsJsonObject("universalServiceIdentifier").get("identifier").getAsString());
+
+        JsonArray observations = order.getAsJsonArray("observation");
+        assertEquals(2, observations.size());
+        assertEquals("7.2", observations.get(0).getAsJsonObject().getAsJsonObject("obx")
+            .getAsJsonArray("observationValue").get(0).getAsString());
+        assertEquals("14.1", observations.get(1).getAsJsonObject().getAsJsonObject("obx")
+            .getAsJsonArray("observationValue").get(0).getAsString());
     }
 
     @Test

--- a/package/hl7/v2/java/src/test/java/com/zerobias/module/hl7/producer/Hl7OperationsIT.java
+++ b/package/hl7/v2/java/src/test/java/com/zerobias/module/hl7/producer/Hl7OperationsIT.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -51,6 +52,13 @@ class Hl7OperationsIT {
         Path f = dir.resolve(rel);
         Files.createDirectories(f.getParent());
         Files.writeString(f, "{\"id\":\"" + id + "\",\"dataTypes\":[],\"properties\":[]}\n");
+    }
+
+    /** Write a schema with an explicit properties list (JSON property objects, comma-separated). */
+    private static void writeSchemaBody(Path dir, String rel, String id, String propsJson) throws Exception {
+        Path f = dir.resolve(rel);
+        Files.createDirectories(f.getParent());
+        Files.writeString(f, "{\"id\":\"" + id + "\",\"dataTypes\":[],\"properties\":[" + propsJson + "]}\n");
     }
 
     private void insert(String cid, String struct, String code) throws Exception {
@@ -190,5 +198,63 @@ class Hl7OperationsIT {
         ProducerException e3 = assertThrows(ProducerException.class,
             () -> invoke(f, "take", Map.of("filter", "not-a-filter")));
         assertEquals("err.illegal.argument", e3.key());
+    }
+
+    // --- er7 / validate (DESIGN §2.5; addressed by message id) -------------
+
+    @Test
+    void er7ReturnsCanonicalWireText(@TempDir Path dir) throws Exception {
+        Hl7ProducerFacade f = facade(dir);
+        JsonObject out = invoke(f, "er7", Map.of("elementKey", "M1"));
+        assertEquals("M1", out.get("controlId").getAsString());
+        assertEquals("ADT_A01", out.get("messageStructure").getAsString());
+        // insert() stored ("raw-" + cid) as the raw ER7 bytes; returned verbatim as UTF-8
+        assertEquals("raw-M1", out.get("er7").getAsString());
+    }
+
+    @Test
+    void er7UnknownMessageIdIs404(@TempDir Path dir) throws Exception {
+        Hl7ProducerFacade f = facade(dir);
+        ProducerException e = assertThrows(ProducerException.class,
+            () -> invoke(f, "er7", Map.of("elementKey", "NOPE")));
+        assertEquals(404, e.httpStatus());
+        assertEquals("err.no.such.object", e.key());
+    }
+
+    /** A facade whose ADT_A01 schema exactly declares what {@code toElement} emits for a seeded row. */
+    private Hl7ProducerFacade validateFacade(Path dir, String adtProps) throws Exception {
+        writeSchemaBody(dir, "schemas/v27/messages/ADT_A01.json", "schema:table:hl7v2.v27.ADT_A01", adtProps);
+        writeSchema(dir, "schemas/v27/messages/ORU_R01.json", "schema:table:hl7v2.v27.ORU_R01");
+        buffer = new BufferStore(dir.resolve("buffer.db").toString(), false);
+        insert("M1", "ADT_A01", "ADT");   // mapped_json {"msh":{messageType:{messageCode:"ADT"}}}
+        SchemaRegistry schemas = SchemaRegistry.fromDirectory(dir);
+        return new Hl7ProducerFacade(buffer, new ObjectTree(buffer, schemas, "v27"), schemas);
+    }
+
+    @Test
+    void validatePassesWhenElementConforms(@TempDir Path dir) throws Exception {
+        // declare exactly the keys toElement produces (msh + envelope); all present → valid
+        Hl7ProducerFacade f = validateFacade(dir,
+            "{\"name\":\"msh\"},{\"name\":\"controlId\",\"required\":true},"
+          + "{\"name\":\"receivedAt\",\"required\":true},{\"name\":\"status\",\"required\":true},"
+          + "{\"name\":\"sourcePort\"},{\"name\":\"leaseId\"}");
+        JsonObject out = invoke(f, "validate", Map.of("elementKey", "M1"));
+        assertEquals("M1", out.get("controlId").getAsString());
+        JsonObject stored = out.getAsJsonObject("stored");
+        assertTrue(stored.get("valid").getAsBoolean(), "expected conformant: " + stored.get("errors"));
+    }
+
+    @Test
+    void validateFlagsMissingRequiredAndUndeclared(@TempDir Path dir) throws Exception {
+        // require a "pid" the (msh-only) element lacks, and don't declare "msh"
+        Hl7ProducerFacade f = validateFacade(dir,
+            "{\"name\":\"pid\",\"required\":true},{\"name\":\"controlId\",\"required\":true},"
+          + "{\"name\":\"receivedAt\",\"required\":true},{\"name\":\"status\",\"required\":true},"
+          + "{\"name\":\"sourcePort\"},{\"name\":\"leaseId\"}");
+        JsonObject stored = invoke(f, "validate", Map.of("elementKey", "M1")).getAsJsonObject("stored");
+        assertFalse(stored.get("valid").getAsBoolean());
+        String errs = stored.getAsJsonArray("errors").toString();
+        assertTrue(errs.contains("pid") && errs.contains("missing required"), errs);
+        assertTrue(errs.contains("msh") && errs.contains("undeclared"), errs);
     }
 }

--- a/package/hl7/v2/java/src/test/java/com/zerobias/module/hl7/producer/SchemaValidatorTest.java
+++ b/package/hl7/v2/java/src/test/java/com/zerobias/module/hl7/producer/SchemaValidatorTest.java
@@ -1,0 +1,113 @@
+package com.zerobias.module.hl7.producer;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit coverage for {@link SchemaValidator} over the table-schema dialect, using a small
+ * hand-written schema set (a message referencing a segment/group and a repeating group)
+ * served through a real {@link SchemaRegistry}. Exercises the structural rules the
+ * {@code ops/validate} op relies on: required-present, undeclared-key, cardinality
+ * (multi ⇒ array), recursion into {@code schema:type:} references, and {@code schema:enum:}
+ * / scalar values treated as accepted leaves.
+ */
+class SchemaValidatorTest {
+
+    private static final String ROOT = "schema:table:hl7v2.vT.ROOT";
+    private SchemaValidator validator;
+
+    @BeforeEach
+    void setUp(@TempDir Path dir) throws Exception {
+        // ROOT = { controlId(req), status(req, enum-ref leaf), patient(req, ->PATIENT),
+        //          orders(multi, ->ORDER) }
+        write(dir, "schemas/vT/messages/ROOT.json", ROOT,
+            "{\"name\":\"controlId\",\"required\":true},"
+          + "{\"name\":\"status\",\"required\":true,\"references\":{\"schemaId\":\"schema:enum:hl7v2.vT.ST\"}},"
+          + "{\"name\":\"patient\",\"required\":true,\"references\":{\"schemaId\":\"schema:type:hl7v2.vT.PATIENT\"}},"
+          + "{\"name\":\"orders\",\"multi\":true,\"references\":{\"schemaId\":\"schema:type:hl7v2.vT.ORDER\"}}");
+        write(dir, "schemas/vT/segments/PATIENT.json", "schema:type:hl7v2.vT.PATIENT",
+            "{\"name\":\"familyName\",\"required\":true}");
+        write(dir, "schemas/vT/groups/ORDER.json", "schema:type:hl7v2.vT.ORDER",
+            "{\"name\":\"orderId\",\"required\":true}");
+        // note: schema:enum:hl7v2.vT.ST is deliberately NOT served — enum refs are leaves.
+        validator = new SchemaValidator(SchemaRegistry.fromDirectory(dir));
+    }
+
+    private static void write(Path dir, String rel, String id, String props) throws Exception {
+        Path f = dir.resolve(rel);
+        Files.createDirectories(f.getParent());
+        Files.writeString(f, "{\"id\":\"" + id + "\",\"dataTypes\":[],\"properties\":[" + props + "]}\n");
+    }
+
+    private Map<String, Object> validElement() {
+        Map<String, Object> el = new LinkedHashMap<>();
+        el.put("controlId", "C1");
+        el.put("status", "F");                              // enum-ref leaf: plain scalar accepted
+        el.put("patient", Map.of("familyName", "DOE"));     // recurse ->PATIENT
+        el.put("orders", List.of(Map.of("orderId", "O1"), Map.of("orderId", "O2")));
+        return el;
+    }
+
+    @Test
+    void conformingElementHasNoErrors() {
+        assertTrue(validator.validate(validElement(), ROOT).isEmpty());
+    }
+
+    @Test
+    void missingRequiredIsReported() {
+        Map<String, Object> el = validElement();
+        el.remove("patient");
+        List<String> errors = validator.validate(el, ROOT);
+        assertEquals(1, errors.size(), errors.toString());
+        assertTrue(errors.get(0).contains("patient") && errors.get(0).contains("missing required"));
+    }
+
+    @Test
+    void undeclaredPropertyIsReported() {
+        Map<String, Object> el = validElement();
+        el.put("bogus", "x");
+        assertTrue(validator.validate(el, ROOT).stream().anyMatch(e -> e.contains("bogus") && e.contains("undeclared")));
+    }
+
+    @Test
+    void repeatingPropertyMustBeArray() {
+        Map<String, Object> el = validElement();
+        el.put("orders", Map.of("orderId", "O1"));   // object where the schema declares multi
+        assertTrue(validator.validate(el, ROOT).stream().anyMatch(e -> e.contains("orders") && e.contains("array")));
+    }
+
+    @Test
+    void recursesIntoReferencedSchema() {
+        Map<String, Object> el = validElement();
+        el.put("patient", Map.of());   // familyName (required in PATIENT) missing
+        assertTrue(validator.validate(el, ROOT).stream()
+            .anyMatch(e -> e.contains("patient.familyName") && e.contains("missing required")));
+    }
+
+    @Test
+    void arrayElementErrorsCarryIndexedPath() {
+        Map<String, Object> el = validElement();
+        el.put("orders", List.of(Map.of("orderId", "O1"), Map.of()));   // second order missing orderId
+        assertTrue(validator.validate(el, ROOT).stream()
+            .anyMatch(e -> e.contains("orders[1].orderId") && e.contains("missing required")));
+    }
+
+    @Test
+    void explicitNullSatisfiesPresenceWithoutRecursing() {
+        Map<String, Object> el = validElement();
+        Map<String, Object> withNull = new LinkedHashMap<>(el);
+        withNull.put("patient", null);   // present-but-null: accepted, no recursion attempted
+        assertFalse(validator.validate(withNull, ROOT).stream().anyMatch(e -> e.contains("patient")));
+    }
+}

--- a/package/hl7/v2/package-lock.json
+++ b/package/hl7/v2/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zerobias-org/module-hl7-v2",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zerobias-org/module-hl7-v2",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "UNLICENSED",
       "dependencies": {
         "@zerobias-org/module-interface-dataproducer": "^2.1.5",


### PR DESCRIPTION
## What & why

Materialized HL7 JSON was **flat** — every segment hoisted to the message root — which contradicts the grouped schema the codegen emits (data-explorer elements failed their own advertised schema). Investigating it against the live UAT target surfaced a second, worse defect: **non-contiguous repeated segments were silently dropped**. HAPI's generic parse slots an interrupted repeat under a numeric-suffixed name (`OBX2`…), and the old `getAll(code)` lookup only ever read the first contiguous run — so e.g. `OBX` rows separated by an `NTE` (ubiquitous in ORU) were lost.

HL7 v2 has no canonical JSON encoding, so the shape is our choice — but correctness (losslessness) is mandatory, and flat is lossy (it destroys OBR↔OBX grouping and merges same-code segments across groups). So: preserve the grouping.

## Changes

- **Group-preserving materializer** — rewrite the walk to a document-ordered, grammar-driven consumer over the structure index, rebuilding nesting (`patient_result → order_observation → observation → obx`) and capturing every occurrence. Real segment code recovered as the leading 3 chars (so digit-ending codes `PV1`/`PV2`/`OM1` survive).
- **`ops/er7`** — returns the canonical raw ER7 (pre-JSON, pre-slot source of truth) for a message, addressed by message id.
- **`ops/validate`** — validates a message against its registered schema, checking **both reps** (the stored element and the form re-materialized from raw ER7), via a new `SchemaValidator` that recurses the table-schema dialect. Distinguishes a stale row (recast would repair) from a live code defect.
- **`sourcePort`** now declared in the schema envelope (it was an undeclared element key).

## Verification

- All touched packages compile against the real deps (incl. `lite-filter`).
- **74 tests pass locally** via a JUnit launcher against real HAPI + SQLite + `lite-filter` + a freshly generated v27 index — including the untouched suites that exercise the changed paths (recast, producer, filter, extension, buffering, registry), so no regressions. New/updated: `MaterializerIT` ORU case (flat→grouped), new `SchemaValidatorTest` (7), `er7`/`validate` coverage in `Hl7OperationsIT` (4).

## ⚠️ Not yet gate-verified

The full `zbb gate` / `mvn verify` was **not** run in the authoring environment (no GitHub Packages auth). It skips the Javalin-backed server, socket-binding listener ITs, codegen wiring into the real build, the image build, and the dataloader step. **Run the gate before merging.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
