### PR TITLE
feat(module-hl7-v2): add Stryker ProCuity and Iatric Jaguar products

### DIFF
--- a/package/hl7/v2/api.yml
+++ b/package/hl7/v2/api.yml
@@ -7,6 +7,8 @@ info:
   x-product-infos:
     - $ref: './node_modules/@zerobias-org/product-auditmation-generic-dataproducer/catalog.yml#/Product'
     - $ref: './node_modules/@zerobias-org/product-hl7-hl7/catalog.yml#/Product'
+    - $ref: './node_modules/@zerobias-org/product-stryker-procuity/catalog.yml#/Product'
+    - $ref: './node_modules/@zerobias-org/product-iatric-jaguar/catalog.yml#/Product'
 # This module implements the DataProducer interface defined in
 # @zerobias-org/module-interface-dataproducer. Interface paths are referenced
 # directly from the interface module; the implementation is Java (see java/).

--- a/package/hl7/v2/gate-stamp.json
+++ b/package/hl7/v2/gate-stamp.json
@@ -1,7 +1,7 @@
 {
-  "version": "1.2.3",
-  "branch": "hl7_debug",
-  "sourceHash": "c6a1fdddd55bed7060b65585b845626fcda7294a37ca3d34e90cea7e75b1a648",
+  "version": "1.2.4-uat.0",
+  "branch": "feat/hl7-add-procuity-jaguar",
+  "sourceHash": "fa8406b8679aee52065ce63480c5432ad8a2179b2791230e69274f7c592ba4db",
   "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "tasks": {
     "validate": "passed",

--- a/package/hl7/v2/package-lock.json
+++ b/package/hl7/v2/package-lock.json
@@ -1,17 +1,19 @@
 {
   "name": "@zerobias-org/module-hl7-v2",
-  "version": "1.2.2",
+  "version": "1.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zerobias-org/module-hl7-v2",
-      "version": "1.2.2",
+      "version": "1.2.4",
       "license": "UNLICENSED",
       "dependencies": {
         "@zerobias-org/module-interface-dataproducer": "^2.1.5",
         "@zerobias-org/product-auditmation-generic-dataproducer": "latest",
         "@zerobias-org/product-hl7-hl7": "latest",
+        "@zerobias-org/product-iatric-jaguar": "latest",
+        "@zerobias-org/product-stryker-procuity": "latest",
         "@zerobias-org/util-connector": "^1.0.31",
         "axios": "^1.13.2"
       },
@@ -1587,6 +1589,24 @@
         "@zerobias-org/vendor-hl7": "latest"
       }
     },
+    "node_modules/@zerobias-org/product-iatric-jaguar": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/product-iatric-jaguar/-/product-iatric-jaguar-1.0.0.tgz",
+      "integrity": "sha512-HTLXqTSnFTGWWLhS/4vsolg63lFPhRgUS1vgBnMyOSWcPeXBYo5JDp0CsDqHTPwAWM8SNTQlGFrodtelkBs91g==",
+      "license": "ISC",
+      "dependencies": {
+        "@zerobias-org/vendor-iatric": "latest"
+      }
+    },
+    "node_modules/@zerobias-org/product-stryker-procuity": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/product-stryker-procuity/-/product-stryker-procuity-1.0.0.tgz",
+      "integrity": "sha512-brnPyHXPD9J05smpZNZfzsmqMlvi+G8Bbkgfk1i0gNz9si1W0Si/Is4vZH6Me8B1z62ETXW/UVLzKiulKYOTxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@zerobias-org/vendor-stryker": "latest"
+      }
+    },
     "node_modules/@zerobias-org/product-zerobias-zerobias": {
       "version": "2.0.2",
       "resolved": "https://pkg.zerobias.org/@zerobias-org/product-zerobias-zerobias/-/product-zerobias-zerobias-2.0.2.tgz",
@@ -1830,6 +1850,18 @@
       "version": "2.0.0",
       "resolved": "https://pkg.zerobias.org/@zerobias-org/vendor-hl7/-/vendor-hl7-2.0.0.tgz",
       "integrity": "sha512-UF+fK876yzQrGy6h3AXkDYp9NaXjWTQa1gehe6RTP1yJs4PAhjHyxOyQAxGPJaR+HNejk10+LhlU4B+hAUevUA==",
+      "license": "ISC"
+    },
+    "node_modules/@zerobias-org/vendor-iatric": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/vendor-iatric/-/vendor-iatric-1.0.0.tgz",
+      "integrity": "sha512-wJQ2/WHradd5Ie2yczflywB9ZbO8n6bh0pue0boJ3LZaEh+zZH8NTwtVYKkzsLGNH96Sk6cdELVIbNLim89PXw==",
+      "license": "ISC"
+    },
+    "node_modules/@zerobias-org/vendor-stryker": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/vendor-stryker/-/vendor-stryker-1.0.0.tgz",
+      "integrity": "sha512-0WbyKp53141f2dp2SIq3Pr9XsxMzN0suywJ8mPfkDZPtrkoP74Jnqe0dwoF0nylO2X4eLLnYWCAzw0SliieFoQ==",
       "license": "ISC"
     },
     "node_modules/@zerobias-org/vendor-zerobias": {

--- a/package/hl7/v2/package.json
+++ b/package/hl7/v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/module-hl7-v2",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "HL7 v2.x MLLP receiver (DataProducer)",
   "type": "module",
   "moduleId": "369d38b0-2c23-43f0-bbc4-33f453ee75c8",
@@ -38,6 +38,8 @@
     "@zerobias-org/module-interface-dataproducer": "^2.1.5",
     "@zerobias-org/product-auditmation-generic-dataproducer": "latest",
     "@zerobias-org/product-hl7-hl7": "latest",
+    "@zerobias-org/product-stryker-procuity": "latest",
+    "@zerobias-org/product-iatric-jaguar": "latest",
     "@zerobias-org/util-connector": "^1.0.31",
     "axios": "^1.13.2"
   },


### PR DESCRIPTION
Adds the two new HL7/REST products to the **HL7 v2 module**'s supported-product list (1.2.3 → **1.2.4**), so the module catalogs them alongside `product-hl7-hl7`.

Per Kevin: Stryker (ProCuity) and Iatric (EasyConnect Jaguar) integrate via the existing HL7 module — this wires them in, the same way the SQL module was repointed for the DB/MediaCare products.

### Changes
- `package.json` — added deps `@zerobias-org/product-stryker-procuity` + `@zerobias-org/product-iatric-jaguar` (kept the existing dataproducer + `product-hl7-hl7` per the module's CLAUDE.md)
- `api.yml` — added both to `x-product-infos` catalog `$ref`s
- `package-lock.json` — regenerated

### Validation
- `./gradlew :hl7:v2:gate` green — Java/maven build + dataloader loaded the module with both new products in its direct deps (`Creating store product version` / imported); stamp refreshed. `dataloaderExec` ran clean (no 401).
- Existing products untouched; only additive.