### PR TITLE
feat(microsoft): add @zerobias-org/module-microsoft-azure-azureresourcegraph

### DIFF
--- a/package/microsoft/azure/azureresourcegraph/.gitignore
+++ b/package/microsoft/azure/azureresourcegraph/.gitignore
@@ -1,0 +1,24 @@
+node_modules/
+dist/
+generated/
+hub-sdk/generated/
+hub-sdk/dist/
+hub-sdk/tsconfig.json
+docs/
+build/
+
+# Ephemeral build artifacts
+eslint.config.js
+eslint.config.mjs
+module-*.yml
+full.yml
+redoc-static.html
+test-results.json
+.env
+
+# OpenAPI generator artifacts
+.openapi-generator
+.openapi-generator-ignore
+
+# Editor
+*.swp

--- a/package/microsoft/azure/azureresourcegraph/.mocharc.json
+++ b/package/microsoft/azure/azureresourcegraph/.mocharc.json
@@ -1,0 +1,4 @@
+{
+  "extension": ["ts"],
+  "node-option": ["import=tsx/esm"]
+}

--- a/package/microsoft/azure/azureresourcegraph/.npmrc
+++ b/package/microsoft/azure/azureresourcegraph/.npmrc
@@ -1,0 +1,6 @@
+@zerobias-com:registry=https://pkg.zerobias.org
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@devsupply:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/microsoft/azure/azureresourcegraph/CHANGELOG.md
+++ b/package/microsoft/azure/azureresourcegraph/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# 1.0.0 (2026-08-04)
+
+### Features
+
+* add Azure Resource Graph module serving the microsoft.azure.azureresourcegraph
+  and microsoft.azure.subscription products (msgraph many-products precedent)
+* `listResources` — queries the Resource Graph `Resources` table at tenant or
+  subscription scope (api-version 2024-04-01, $skipToken paging)
+* `listResourceContainers` — queries the `ResourceContainers` table
+  (subscriptions, resource groups, management groups)
+
+**Note:** implements 2 of 3 planned operations — `listSubscriptions` is
+deliberately deferred to a later step.

--- a/package/microsoft/azure/azureresourcegraph/README.md
+++ b/package/microsoft/azure/azureresourcegraph/README.md
@@ -1,0 +1,44 @@
+# microsoft-azure-azureresourcegraph Hub Module
+
+Azure Resource Graph connector — inventories Azure resources and resource
+containers (subscriptions, resource groups, management groups) through the
+Resource Graph query API (api-version `2024-04-01`). One module serving two
+products: `microsoft.azure.azureresourcegraph` and
+`microsoft.azure.subscription`.
+
+## Authentication and authorization
+
+Azure AD (Entra ID) client credentials: `directoryId` + `clientId` /
+`clientSecret`, exchanged for a token with the Azure Resource Manager audience
+(scope `https://management.azure.com/.default`).
+
+The service principal needs the **Azure RBAC Reader** role at subscription or
+management-group scope. Resource Graph enforces read access per object: rows
+the credential cannot read are omitted from results, and the API returns 403
+only when nothing is readable at all. Throttling is reported via the
+`x-ms-user-quota-remaining` and `x-ms-user-quota-resets-after` response
+headers.
+
+## Usage
+
+```typescript
+import { newAzureResourceGraph } from '@zerobias-org/module-microsoft-azure-azureresourcegraph';
+
+const arg = newAzureResourceGraph();
+await arg.connect({ directoryId, clientId, clientSecret });
+
+const results = new PagedResults<Resource>();
+await arg.getResourceApi().list(results);            // tenant scope
+await arg.getResourceApi().list(results, [subId]);   // subscription scope
+await arg.getResourceContainerApi().list(results);   // subscriptions/RGs/MGs
+```
+
+Paging follows the Resource Graph contract: `options.$top` (max 1000) and
+`options.$skip` on the first page, then the response `$skipToken` is carried in
+`PagedResults.pageToken` for subsequent pages until absent.
+
+# Test
+
+E2E tests live in `test/e2e/` and skip unless `AZURE_DIRECTORY_ID`,
+`AZURE_CLIENT_ID` and `AZURE_CLIENT_SECRET` are set (optionally
+`AZURE_SUBSCRIPTION_ID` for the scoped-list test).

--- a/package/microsoft/azure/azureresourcegraph/api.yml
+++ b/package/microsoft/azure/azureresourcegraph/api.yml
@@ -1,0 +1,232 @@
+openapi: 3.0.3
+info:
+  x-impl-name: AzureResourceGraph
+  x-product-infos:
+    - $ref: './node_modules/@zerobias-org/product-microsoft-azure-azureresourcegraph/catalog.yml#/Product'
+    - $ref: './node_modules/@zerobias-org/product-microsoft-azure-subscription/catalog.yml#/Product'
+  version: '1.0.0'
+  title: '@zerobias-org/module-microsoft-azure-azureresourcegraph'
+  description: 'Azure Resource Graph'
+paths:
+  /resources:
+    get:
+      tags:
+        - resource
+      summary: Retrieves the list of Azure resources visible to the connection via Azure Resource Graph
+      description: >-
+        Queries the Azure Resource Graph `Resources` table
+        (POST https://management.azure.com/providers/Microsoft.ResourceGraph/resources?api-version=2024-04-01).
+        When no subscription scope is provided the query runs at tenant scope and returns
+        every resource the service principal can read. Resource Graph returns no rows for
+        objects the credential cannot read, and responds 403 only when nothing is readable.
+      operationId: listResources
+      x-method-name: list
+      security:
+        - azure-resource-graph:
+            - https://management.azure.com/.default
+      parameters:
+        - $ref: '#/components/parameters/subscriptionIdsParam'
+        - $ref: '#/components/parameters/pageSizeParam'
+        - $ref: '#/components/parameters/pageTokenParam'
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            link:
+              $ref: '#/components/headers/pagedLinkHeader'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Resource'
+  /resourceContainers:
+    get:
+      tags:
+        - resourceContainer
+      summary: Retrieves the list of Azure resource containers via Azure Resource Graph
+      description: >-
+        Queries the Azure Resource Graph `ResourceContainers` table
+        (POST https://management.azure.com/providers/Microsoft.ResourceGraph/resources?api-version=2024-04-01).
+        Returns subscriptions (microsoft.resources/subscriptions), resource groups
+        (microsoft.resources/subscriptions/resourcegroups) and management groups
+        (microsoft.management/managementgroups) visible to the connection.
+      operationId: listResourceContainers
+      x-method-name: list
+      security:
+        - azure-resource-graph:
+            - https://management.azure.com/.default
+      parameters:
+        - $ref: '#/components/parameters/subscriptionIdsParam'
+        - $ref: '#/components/parameters/pageSizeParam'
+        - $ref: '#/components/parameters/pageTokenParam'
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            link:
+              $ref: '#/components/headers/pagedLinkHeader'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ResourceContainer'
+components:
+  securitySchemes:
+    azure-resource-graph:
+      type: oauth2
+      description: >-
+        Azure AD (Entra ID) client-credentials flow with an ARM token audience.
+        The service principal needs the Azure RBAC Reader role at subscription or
+        management-group scope. Resource Graph enforces read access per object:
+        unreadable objects are silently omitted, and the API returns 403 only when
+        the credential can read nothing at all. Throttling is reported via the
+        x-ms-user-quota-remaining and x-ms-user-quota-resets-after response headers.
+      flows:
+        clientCredentials:
+          tokenUrl: https://login.microsoftonline.com/{directoryId}/oauth2/v2.0/token
+          scopes:
+            https://management.azure.com/.default: >-
+              Azure Resource Manager token audience; effective permissions come from
+              the Azure RBAC Reader role assigned to the service principal.
+  headers:
+    pagedLinkHeader:
+      $ref: './node_modules/@zerobias-org/types-core/schema/pagedLinkHeader.yml'
+  parameters:
+    pageSizeParam:
+      $ref: './node_modules/@zerobias-org/types-core/schema/pageSizeParam.yml'
+    pageTokenParam:
+      $ref: './node_modules/@zerobias-org/types-core/schema/pageTokenParam.yml'
+    subscriptionIdsParam:
+      name: subscriptionIds
+      in: query
+      description: >-
+        Optional list of Azure subscription IDs to scope the query to. When omitted
+        the query runs at tenant scope (supported on api-version 2024-04-01) and
+        returns results from every subscription and management group the service
+        principal can read.
+      required: false
+      schema:
+        type: array
+        items:
+          type: string
+          format: uuid
+          description: An Azure subscription ID.
+  schemas:
+    Resource:
+      type: object
+      description: >-
+        A resource row from the Azure Resource Graph `Resources` table
+        (options.resultFormat objectArray). Maps toward the
+        AzureResourceGraphResource class of
+        @zerobias-org/schema-microsoft-azure-azureresourcegraph.
+      properties:
+        id:
+          type: string
+          description: The full Azure Resource Manager ID of the resource.
+        name:
+          type: string
+          description: The name of the resource.
+        type:
+          type: string
+          description: The resource type, e.g. microsoft.compute/virtualmachines.
+        tenantId:
+          type: string
+          description: The Azure AD tenant (directory) ID the resource belongs to.
+        kind:
+          type: string
+          description: The resource kind, when the resource provider reports one.
+        location:
+          type: string
+          description: The Azure region the resource resides in.
+        resourceGroup:
+          type: string
+          description: The name of the resource group containing the resource.
+        subscriptionId:
+          type: string
+          description: The ID of the subscription containing the resource.
+        managedBy:
+          type: string
+          description: The ID of the resource managing this resource, if any.
+        sku:
+          type: object
+          description: The SKU of the resource, as reported by the resource provider.
+          additionalProperties: true
+        plan:
+          type: object
+          description: The marketplace plan of the resource, if any.
+          additionalProperties: true
+        properties:
+          type: object
+          description: >-
+            The resource-type-specific properties bag as returned by Azure Resource
+            Graph. Content varies by resource type.
+          additionalProperties: true
+        tags:
+          type: object
+          description: The tags assigned to the resource.
+          additionalProperties:
+            type: string
+            description: Tag value.
+        identity:
+          type: object
+          description: The managed identity of the resource, if any.
+          additionalProperties: true
+        zones:
+          type: array
+          description: The availability zones the resource is deployed to.
+          items:
+            type: string
+            description: An availability zone identifier.
+        extendedLocation:
+          type: object
+          description: The extended location of the resource, if any.
+          additionalProperties: true
+    ResourceContainer:
+      type: object
+      description: >-
+        A row from the Azure Resource Graph `ResourceContainers` table. Covers
+        subscriptions (microsoft.resources/subscriptions), resource groups
+        (microsoft.resources/subscriptions/resourcegroups) and management groups
+        (microsoft.management/managementgroups).
+      properties:
+        id:
+          type: string
+          description: The full Azure Resource Manager ID of the container.
+        name:
+          type: string
+          description: The display name of the container.
+        type:
+          type: string
+          description: >-
+            The container type: microsoft.resources/subscriptions,
+            microsoft.resources/subscriptions/resourcegroups or
+            microsoft.management/managementgroups.
+        tenantId:
+          type: string
+          description: The Azure AD tenant (directory) ID the container belongs to.
+        location:
+          type: string
+          description: The Azure region of the container, when applicable.
+        resourceGroup:
+          type: string
+          description: For resource group rows, the resource group name.
+        subscriptionId:
+          type: string
+          description: The ID of the subscription the container belongs to.
+        managedBy:
+          type: string
+          description: The ID of the resource managing this container, if any.
+        properties:
+          type: object
+          description: >-
+            The container-type-specific properties bag, e.g. subscription state and
+            policies for subscription rows.
+          additionalProperties: true
+        tags:
+          type: object
+          description: The tags assigned to the container.
+          additionalProperties:
+            type: string
+            description: Tag value.

--- a/package/microsoft/azure/azureresourcegraph/build.gradle.kts
+++ b/package/microsoft/azure/azureresourcegraph/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    id("zb.typescript-connector")
+}

--- a/package/microsoft/azure/azureresourcegraph/connectionProfile.yml
+++ b/package/microsoft/azure/azureresourcegraph/connectionProfile.yml
@@ -1,0 +1,37 @@
+type: object
+allOf:
+  - $ref: './node_modules/@zerobias-org/types-core/schema/oauthTokenProfile.yml'
+  - $ref: './node_modules/@zerobias-org/types-core/schema/oauthTokenState.yml'
+  - type: object
+    description: >
+      Additional properties for an Azure Resource Graph Connection.
+      * directoryId is required in both oauth and non oauth connections
+      * client properties are required when setting up a non-oauth connection (alongside directoryId)
+      * tokens are acquired with the Azure Resource Manager audience (scope https://management.azure.com/.default);
+        the service principal needs the Azure RBAC Reader role at subscription or management-group scope
+    required:
+      - directoryId
+    x-oauth-providers:
+      - microsoft.oauth
+    x-ui-required:
+      - directoryId
+      - clientId
+      - clientSecret
+    x-ui-hidden:
+      - tokenType
+      - accessToken
+      - refreshToken
+      - expiresIn
+      - scope
+      - url
+    properties:
+      directoryId:
+        type: string
+        example: myorg.onmicrosoft.com
+      clientId:
+        type: string
+        example: b42e570c-26ae-4a96-bb8e-eed2454be5b7
+      clientSecret:
+        type: string
+        format: password
+        example: r1J6m2@oKbT6$%gZp9^s8#fE3qA1

--- a/package/microsoft/azure/azureresourcegraph/connectionState.yml
+++ b/package/microsoft/azure/azureresourcegraph/connectionState.yml
@@ -1,0 +1,5 @@
+type: object
+allOf:
+  - $ref: './node_modules/@zerobias-org/types-core/schema/oauthTokenState.yml'
+  - type: object
+    properties: {}

--- a/package/microsoft/azure/azureresourcegraph/hub-sdk/package.json
+++ b/package/microsoft/azure/azureresourcegraph/hub-sdk/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@zerobias-org/hub-sdk-microsoft-azure-azureresourcegraph",
+  "version": "0.0.0",
+  "description": "Hub SDK for microsoft-azure-azureresourcegraph module",
+  "type": "module",
+  "main": "dist/api/index.js",
+  "types": "dist/api/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/api/index.d.ts",
+      "import": "./dist/api/index.js"
+    },
+    "./api": {
+      "types": "./dist/api/index.d.ts",
+      "import": "./dist/api/index.js"
+    },
+    "./model": {
+      "types": "./dist/model/index.d.ts",
+      "import": "./dist/model/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "peerDependencies": {
+    "@zerobias-org/types-core-js": "^1.2.19",
+    "@zerobias-org/util-connector": "^1.0.40",
+    "axios": "^1.0.0"
+  },
+  "publishConfig": {
+    "access": "restricted"
+  }
+}

--- a/package/microsoft/azure/azureresourcegraph/package.json
+++ b/package/microsoft/azure/azureresourcegraph/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@zerobias-org/module-microsoft-azure-azureresourcegraph",
+  "version": "1.0.0",
+  "description": "Azure Resource Graph",
+  "moduleId": "6dc35a05-f3ba-4dfb-9aa5-2c6a9a1f63b5",
+  "type": "module",
+  "main": "dist/src/index.js",
+  "author": "team@zerobias.com",
+  "license": "UNLICENSED",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zerobias-org/module",
+    "directory": "package/microsoft/azure/azureresourcegraph"
+  },
+  "publishConfig": {
+    "registry": "https://pkg.zerobias.org/"
+  },
+  "scripts": {
+    "clean": "rm -rf build/ dist/ generated/ hub-sdk/generated hub-sdk/tsconfig.json hub-sdk/dist module-microsoft-azure-azureresourcegraph.yml full.yml"
+  },
+  "files": [
+    "dist",
+    "generated/api/manifest.json",
+    "api.yml",
+    "connectionProfile.yml",
+    "connectionState.yml"
+  ],
+  "zerobias": {
+    "package": "microsoft.azure.azureresourcegraph.module",
+    "dataloader-version": "1.0.0",
+    "import-artifact": "module"
+  },
+  "overrides": {
+    "diff": ">=8.0.3",
+    "serialize-javascript": ">=7.0.3"
+  },
+  "dependencies": {
+    "@zerobias-org/logger": "^3.0.9",
+    "@zerobias-org/product-microsoft-azure-azureresourcegraph": "^2.0.2",
+    "@zerobias-org/product-microsoft-azure-subscription": "^2.0.2",
+    "@zerobias-org/util-connector": "^1.0.40",
+    "@zerobias-org/util-hub-module-utils": "^2.0.49",
+    "axios": "1.15.0"
+  },
+  "peerDependencies": {
+    "@zerobias-org/types-core": "^1.0.24",
+    "@zerobias-org/types-core-js": "^1.2.23"
+  },
+  "devDependencies": {
+    "@redocly/cli": "2.28.1",
+    "@types/chai": "4.3.20",
+    "@types/mocha": "10.0.10",
+    "@types/node": "22.19.17",
+    "@zerobias-org/eslint-config": "^1.0.38",
+    "@zerobias-org/module-test-client": "^1.0.5",
+    "@zerobias-org/util-api-client-base": "^1.0.44",
+    "@zerobias-org/util-codegen": "^2.0.49",
+    "chai": "4.5.0",
+    "mocha": "11.7.5",
+    "nock": "14.0.12",
+    "tsx": "4.21.0",
+    "typescript": "5.9.3"
+  }
+}

--- a/package/microsoft/azure/azureresourcegraph/src/AzureResourceGraphClient.ts
+++ b/package/microsoft/azure/azureresourcegraph/src/AzureResourceGraphClient.ts
@@ -1,0 +1,278 @@
+import axios, { AxiosInstance, AxiosError } from 'axios';
+import {
+  InvalidCredentialsError,
+  InvalidInputError,
+  NoSuchObjectError,
+  NotConnectedError,
+  PagedResults,
+  RateLimitExceededError,
+  UnauthorizedError,
+  UnexpectedError
+} from '@zerobias-org/types-core-js';
+import { ConnectionProfile } from '../generated/model/ConnectionProfile.js';
+import { ConnectionState } from '../generated/model/index.js';
+
+const BASE_TOKEN_URI = 'https://login.microsoftonline.com/';
+const TOKEN_ENDPOINT = '/oauth2/v2.0/token';
+const ARM_SCOPE = 'https://management.azure.com/.default';
+const ARG_RESOURCES_URL = 'https://management.azure.com/providers/Microsoft.ResourceGraph/resources';
+const ARG_API_VERSION = '2024-04-01';
+const MAX_TOP_PARAM_VALUE = 1000;
+
+/** The paged envelope returned by the Resource Graph resources endpoint. */
+export interface ArgQueryResponse {
+  data: Record<string, unknown>[];
+  count?: number;
+  totalRecords?: number;
+  resultTruncated?: string | boolean;
+  $skipToken?: string;
+}
+
+export class AzureResourceGraphClient {
+  private httpClient: AxiosInstance | null = null;
+
+  private connected = false;
+
+  private connectionProfile?: ConnectionProfile;
+
+  private accessToken: string | null = null;
+
+  private tokenExpiresAt: Date | null = null;
+
+  async connect(profile: ConnectionProfile): Promise<ConnectionState> {
+    if (!profile.directoryId) {
+      throw new InvalidCredentialsError();
+    }
+    if (!profile.accessToken && !(profile.clientId && profile.clientSecret)) {
+      throw new InvalidCredentialsError();
+    }
+
+    this.connectionProfile = profile;
+
+    if (profile.clientId && profile.clientSecret) {
+      // compatibility/manual mode — acquire an ARM-audience token via client credentials
+      await this.acquireAccessToken();
+    } else {
+      // oauth mode — a token was provided on the profile by the platform
+      this.accessToken = `${profile.accessToken}`;
+      this.tokenExpiresAt = profile.expiresIn
+        ? new Date(Date.now() + Number(profile.expiresIn) * 1000)
+        : null;
+    }
+
+    if (!this.accessToken) {
+      throw new InvalidCredentialsError();
+    }
+
+    this.httpClient = axios.create({
+      timeout: 60_000,
+      headers: {
+        Authorization: `Bearer ${this.accessToken}`,
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+    });
+
+    // Probe: a minimal one-row tenant-scope query proves both the token audience
+    // and that the principal can read at least something (ARG 403s when nothing
+    // at all is readable).
+    await this.query('Resources', undefined, { $top: 1, resultFormat: 'objectArray' }, true);
+    this.connected = true;
+
+    return this.getConnectionState() as ConnectionState;
+  }
+
+  async isConnected(): Promise<boolean> {
+    if (!this.connected || !this.httpClient) {
+      return false;
+    }
+    if (this.tokenExpiresAt) {
+      return this.tokenExpiresAt.getTime() > Date.now();
+    }
+    return true;
+  }
+
+  async disconnect(): Promise<void> {
+    this.httpClient = null;
+    this.connected = false;
+    this.accessToken = null;
+    this.tokenExpiresAt = null;
+    delete this.connectionProfile;
+  }
+
+  async refresh(): Promise<ConnectionState> {
+    // Client-credentials tokens are not refreshed — they are re-acquired.
+    if (!this.connectionProfile?.clientId || !this.connectionProfile?.clientSecret) {
+      throw new NotConnectedError();
+    }
+    await this.acquireAccessToken();
+    if (this.httpClient && this.accessToken) {
+      this.httpClient.defaults.headers.Authorization = `Bearer ${this.accessToken}`;
+    }
+    return this.getConnectionState() as ConnectionState;
+  }
+
+  getConnectionState(): ConnectionState | null {
+    if (!this.accessToken) {
+      return null;
+    }
+    const expiresIn = this.tokenExpiresAt
+      ? Math.max(0, Math.floor((this.tokenExpiresAt.getTime() - Date.now()) / 1000))
+      : undefined;
+    return {
+      accessToken: this.accessToken,
+      expiresIn,
+    } as ConnectionState;
+  }
+
+  /**
+   * Executes one Resource Graph query call.
+   *
+   * @param queryString - the KQL query (e.g. `Resources` or `ResourceContainers`)
+   * @param subscriptions - optional subscription IDs to scope to; tenant scope when omitted
+   * @param options - the ARG options bag ($top/$skip/$skipToken/resultFormat)
+   * @param connecting - allow the call before `connected` flips (connection probe)
+   */
+  async query(
+    queryString: string,
+    subscriptions: string[] | undefined,
+    options: Record<string, unknown>,
+    connecting = false
+  ): Promise<ArgQueryResponse> {
+    if (!this.httpClient || (!connecting && !this.connected)) {
+      throw new NotConnectedError();
+    }
+
+    const body: Record<string, unknown> = { query: queryString, options };
+    if (subscriptions && subscriptions.length > 0) {
+      body.subscriptions = subscriptions;
+    }
+
+    try {
+      const response = await this.httpClient.post(
+        `${ARG_RESOURCES_URL}?api-version=${ARG_API_VERSION}`,
+        body
+      );
+      return response.data as ArgQueryResponse;
+    } catch (error) {
+      if (axios.isAxiosError(error)) {
+        AzureResourceGraphClient.handleError(error);
+      }
+      throw new UnexpectedError(`${error}`);
+    }
+  }
+
+  /**
+   * Populates a PagedResults from an ARG table using the documented paging
+   * contract: options.$top (max 1000) + options.$skip on the first page, then
+   * options.$skipToken (which overrides $skip/$top) on subsequent pages; stop
+   * when the response carries no $skipToken.
+   */
+  async listQuery<T>(
+    results: PagedResults<T>,
+    table: string,
+    subscriptions: string[] | undefined,
+    mapper: (row: Record<string, unknown>) => T
+  ): Promise<void> {
+    if (results.pageSize > MAX_TOP_PARAM_VALUE) {
+      throw new InvalidInputError(
+        `pageSize cannot be greater than the maximum allowed value (${MAX_TOP_PARAM_VALUE})`,
+        results.pageSize
+      );
+    }
+
+    const options: Record<string, unknown> = {
+      resultFormat: 'objectArray',
+      $top: results.pageSize,
+    };
+    if (results.pageToken) {
+      // $skipToken overrides $skip/$top server-side and encodes the continuation
+      options.$skipToken = results.pageToken;
+    } else if (results.pageNumber > 1) {
+      options.$skip = (results.pageNumber - 1) * results.pageSize;
+    }
+
+    const response = await this.query(table, subscriptions, options);
+
+    results.items = (response.data || []).map(mapper);
+    if (response.totalRecords !== undefined) {
+      results.count = response.totalRecords;
+    }
+    // Absent $skipToken means the last page — pageToken clears and paging stops.
+    results.pageToken = response.$skipToken;
+  }
+
+  private async acquireAccessToken(): Promise<void> {
+    if (!this.connectionProfile?.clientId || !this.connectionProfile?.clientSecret) {
+      throw new InvalidCredentialsError();
+    }
+    const tokenUri = `${BASE_TOKEN_URI}${this.connectionProfile.directoryId}${TOKEN_ENDPOINT}`;
+    const postData = new URLSearchParams({
+      client_id: `${this.connectionProfile.clientId}`,
+      client_secret: `${this.connectionProfile.clientSecret}`,
+      scope: ARM_SCOPE,
+      grant_type: 'client_credentials',
+    });
+
+    let response;
+    try {
+      response = await axios.post(tokenUri, postData.toString(), {
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        timeout: 60_000,
+      });
+    } catch (error) {
+      if (axios.isAxiosError(error) && error.response?.status === 400) {
+        // AADSTS errors (bad tenant, bad client, bad secret) come back as 400
+        throw new InvalidCredentialsError();
+      }
+      if (axios.isAxiosError(error)) {
+        AzureResourceGraphClient.handleError(error);
+      }
+      throw new UnexpectedError(`${error}`);
+    }
+
+    const accessToken = response?.data?.access_token;
+    if (!accessToken) {
+      throw new InvalidCredentialsError();
+    }
+    this.accessToken = accessToken;
+    const expiresIn = Number(response?.data?.expires_in);
+    this.tokenExpiresAt = Number.isFinite(expiresIn)
+      ? new Date(Date.now() + expiresIn * 1000)
+      : null;
+  }
+
+  private static handleError = (error: AxiosError): never => {
+    const status = error.response?.status || 500;
+    const responseData = error.response?.data as Record<string, any> | undefined;
+    const message = responseData?.error?.message
+      || responseData?.message
+      || error.message
+      || 'Unknown error';
+
+    switch (status) {
+      case 400: {
+        throw new InvalidInputError('request', message);
+      }
+      case 401: {
+        throw new InvalidCredentialsError();
+      }
+      case 403: {
+        // ARG returns 403 when the principal can read no objects at all;
+        // partial access yields 200 with unreadable rows omitted.
+        throw new UnauthorizedError();
+      }
+      case 404: {
+        throw new NoSuchObjectError('resource', 'unknown');
+      }
+      case 429: {
+        // Throttled — quota headers: x-ms-user-quota-remaining /
+        // x-ms-user-quota-resets-after describe when the quota window resets.
+        throw new RateLimitExceededError();
+      }
+      default: {
+        throw new UnexpectedError(message, status);
+      }
+    }
+  };
+}

--- a/package/microsoft/azure/azureresourcegraph/src/AzureResourceGraphImpl.ts
+++ b/package/microsoft/azure/azureresourcegraph/src/AzureResourceGraphImpl.ts
@@ -1,0 +1,75 @@
+import {
+  ConnectionMetadata,
+  ConnectionStatus,
+  OperationSupportStatus,
+  OperationSupportStatusDef
+} from '@zerobias-org/types-core-js';
+import {
+  AzureResourceGraphConnector,
+  ResourceApi,
+  ResourceContainerApi,
+  wrapResourceContainerProducer,
+  wrapResourceProducer,
+} from '../generated/api/index.js';
+import { ConnectionProfile } from '../generated/model/ConnectionProfile.js';
+import { ConnectionState } from '../generated/model/index.js';
+import { AzureResourceGraphClient } from './AzureResourceGraphClient.js';
+import { ResourceContainerProducerImpl } from './ResourceContainerProducerImpl.js';
+import { ResourceProducerImpl } from './ResourceProducerImpl.js';
+
+export class AzureResourceGraphImpl implements AzureResourceGraphConnector {
+  private client: AzureResourceGraphClient;
+
+  private resourceApiProducer?: ResourceApi;
+
+  private resourceContainerApiProducer?: ResourceContainerApi;
+
+  constructor() {
+    this.client = new AzureResourceGraphClient();
+  }
+
+  async connect(connectionProfile: ConnectionProfile): Promise<ConnectionState> {
+    return this.client.connect(connectionProfile);
+  }
+
+  async refresh(
+    _connectionProfile: ConnectionProfile,
+    _connectionState: ConnectionState
+  ): Promise<ConnectionState> {
+    return this.client.refresh();
+  }
+
+  async isConnected(): Promise<boolean> {
+    return this.client.isConnected();
+  }
+
+  async disconnect(): Promise<void> {
+    return this.client.disconnect();
+  }
+
+  async metadata(): Promise<ConnectionMetadata> {
+    // ALWAYS return ConnectionStatus.Down - replaced by platform
+    return new ConnectionMetadata(ConnectionStatus.Down);
+  }
+
+  async isSupported(_operationId: string): Promise<OperationSupportStatusDef> {
+    // ALWAYS return OperationSupportStatus.Maybe - replaced by platform
+    return OperationSupportStatus.Maybe;
+  }
+
+  getResourceApi(): ResourceApi {
+    if (!this.resourceApiProducer) {
+      this.resourceApiProducer = wrapResourceProducer(new ResourceProducerImpl(this.client));
+    }
+    return this.resourceApiProducer;
+  }
+
+  getResourceContainerApi(): ResourceContainerApi {
+    if (!this.resourceContainerApiProducer) {
+      this.resourceContainerApiProducer = wrapResourceContainerProducer(
+        new ResourceContainerProducerImpl(this.client)
+      );
+    }
+    return this.resourceContainerApiProducer;
+  }
+}

--- a/package/microsoft/azure/azureresourcegraph/src/Mappers.ts
+++ b/package/microsoft/azure/azureresourcegraph/src/Mappers.ts
@@ -1,0 +1,48 @@
+import { Resource, ResourceContainer } from '../generated/model/index.js';
+
+/**
+ * Maps an Azure Resource Graph `Resources` row (options.resultFormat
+ * objectArray) to the module Resource model. Rows arrive as flat objects keyed
+ * by ARG column name.
+ */
+export function toResource(row: Record<string, unknown>): Resource {
+  return {
+    id: row.id,
+    name: row.name,
+    type: row.type,
+    tenantId: row.tenantId,
+    kind: row.kind || undefined,
+    location: row.location,
+    resourceGroup: row.resourceGroup,
+    subscriptionId: row.subscriptionId,
+    managedBy: row.managedBy || undefined,
+    sku: row.sku ?? undefined,
+    plan: row.plan ?? undefined,
+    properties: row.properties ?? undefined,
+    tags: row.tags ?? undefined,
+    identity: row.identity ?? undefined,
+    zones: row.zones ?? undefined,
+    extendedLocation: row.extendedLocation ?? undefined,
+  } as Resource;
+}
+
+/**
+ * Maps an Azure Resource Graph `ResourceContainers` row to the module
+ * ResourceContainer model. Covers microsoft.resources/subscriptions,
+ * microsoft.resources/subscriptions/resourcegroups and
+ * microsoft.management/managementgroups rows.
+ */
+export function toResourceContainer(row: Record<string, unknown>): ResourceContainer {
+  return {
+    id: row.id,
+    name: row.name,
+    type: row.type,
+    tenantId: row.tenantId,
+    location: row.location || undefined,
+    resourceGroup: row.resourceGroup || undefined,
+    subscriptionId: row.subscriptionId || undefined,
+    managedBy: row.managedBy || undefined,
+    properties: row.properties ?? undefined,
+    tags: row.tags ?? undefined,
+  } as ResourceContainer;
+}

--- a/package/microsoft/azure/azureresourcegraph/src/ResourceContainerProducerImpl.ts
+++ b/package/microsoft/azure/azureresourcegraph/src/ResourceContainerProducerImpl.ts
@@ -1,0 +1,21 @@
+import type { PagedResults } from '@zerobias-org/types-core-js';
+import type { ResourceContainerProducerApi } from '../generated/api/index.js';
+import type { ResourceContainer } from '../generated/model/index.js';
+import { AzureResourceGraphClient } from './AzureResourceGraphClient.js';
+import { toResourceContainer } from './Mappers.js';
+
+export class ResourceContainerProducerImpl implements ResourceContainerProducerApi {
+  constructor(private client: AzureResourceGraphClient) { }
+
+  async list(
+    results: PagedResults<ResourceContainer>,
+    subscriptionIds?: Array<string>
+  ): Promise<void> {
+    return this.client.listQuery(
+      results,
+      'ResourceContainers',
+      subscriptionIds?.map((id) => `${id}`),
+      toResourceContainer
+    );
+  }
+}

--- a/package/microsoft/azure/azureresourcegraph/src/ResourceProducerImpl.ts
+++ b/package/microsoft/azure/azureresourcegraph/src/ResourceProducerImpl.ts
@@ -1,0 +1,21 @@
+import type { PagedResults } from '@zerobias-org/types-core-js';
+import type { ResourceProducerApi } from '../generated/api/index.js';
+import type { Resource } from '../generated/model/index.js';
+import { AzureResourceGraphClient } from './AzureResourceGraphClient.js';
+import { toResource } from './Mappers.js';
+
+export class ResourceProducerImpl implements ResourceProducerApi {
+  constructor(private client: AzureResourceGraphClient) { }
+
+  async list(
+    results: PagedResults<Resource>,
+    subscriptionIds?: Array<string>
+  ): Promise<void> {
+    return this.client.listQuery(
+      results,
+      'Resources',
+      subscriptionIds?.map((id) => `${id}`),
+      toResource
+    );
+  }
+}

--- a/package/microsoft/azure/azureresourcegraph/src/index.ts
+++ b/package/microsoft/azure/azureresourcegraph/src/index.ts
@@ -1,0 +1,10 @@
+import type { AzureResourceGraphConnector } from '../generated/api/index.js';
+import { AzureResourceGraphImpl } from './AzureResourceGraphImpl.js';
+
+export * from '../generated/api/index.js';
+export * from '../generated/model/index.js';
+
+/** Factory function — the primary entry point for creating module instances. */
+export function newAzureResourceGraph(): AzureResourceGraphConnector {
+  return new AzureResourceGraphImpl();
+}

--- a/package/microsoft/azure/azureresourcegraph/test/e2e/azureresourcegraph.test.ts
+++ b/package/microsoft/azure/azureresourcegraph/test/e2e/azureresourcegraph.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Azure Resource Graph Module E2E Tests — one test suite, three impls.
+ *
+ * The describeModule framework owns the connect/isConnected/disconnect
+ * lifecycle, so those paths are not re-exercised here. Requires a service
+ * principal with the Azure RBAC Reader role at subscription or
+ * management-group scope (see test/e2e/constants.ts for the env contract).
+ */
+
+import { expect } from 'chai';
+import { CoreError, PagedResults } from '@zerobias-org/types-core-js';
+import { describeModule } from '@zerobias-org/module-test-client';
+import type { AzureResourceGraph } from '../../hub-sdk/generated/api/index.js';
+import { AZURE_SUBSCRIPTION_ID, hasCredentials } from './constants.js';
+
+describeModule<AzureResourceGraph>('Azure Resource Graph Module', (client) => {
+
+  before(function () {
+    if (!hasCredentials()) {
+      this.skip();
+    }
+  });
+
+  describe('ResourceApi.list', () => {
+    it('should list resources at tenant scope', async () => {
+      const results = new PagedResults<any>();
+      results.pageSize = 10;
+      await client.getResourceApi().list(results);
+      expect(results.items).to.be.an('array');
+      for (const resource of results.items) {
+        expect(resource).to.have.property('id');
+        expect(resource).to.have.property('type');
+      }
+    });
+
+    it('should list resources scoped to a subscription', async function () {
+      if (!AZURE_SUBSCRIPTION_ID) {
+        this.skip();
+      }
+      const results = new PagedResults<any>();
+      results.pageSize = 10;
+      await client.getResourceApi().list(results, [AZURE_SUBSCRIPTION_ID]);
+      expect(results.items).to.be.an('array');
+      for (const resource of results.items) {
+        expect(resource.subscriptionId).to.equal(AZURE_SUBSCRIPTION_ID);
+      }
+    });
+  });
+
+  describe('ResourceContainerApi.list', () => {
+    it('should list resource containers', async () => {
+      const results = new PagedResults<any>();
+      results.pageSize = 10;
+      await client.getResourceContainerApi().list(results);
+      expect(results.items).to.be.an('array');
+      expect(results.items.length).to.be.greaterThan(0);
+      for (const container of results.items) {
+        expect(container).to.have.property('id');
+        expect(container.type).to.be.oneOf([
+          'microsoft.resources/subscriptions',
+          'microsoft.resources/subscriptions/resourcegroups',
+          'microsoft.management/managementgroups',
+        ]);
+      }
+    });
+  });
+
+}, (data) => CoreError.deserialize(data));

--- a/package/microsoft/azure/azureresourcegraph/test/e2e/constants.ts
+++ b/package/microsoft/azure/azureresourcegraph/test/e2e/constants.ts
@@ -1,0 +1,8 @@
+export const AZURE_DIRECTORY_ID = process.env.AZURE_DIRECTORY_ID ?? '';
+export const AZURE_CLIENT_ID = process.env.AZURE_CLIENT_ID ?? '';
+export const AZURE_CLIENT_SECRET = process.env.AZURE_CLIENT_SECRET ?? '';
+export const AZURE_SUBSCRIPTION_ID = process.env.AZURE_SUBSCRIPTION_ID ?? '';
+
+export function hasCredentials(): boolean {
+  return !!(AZURE_DIRECTORY_ID && AZURE_CLIENT_ID && AZURE_CLIENT_SECRET);
+}

--- a/package/microsoft/azure/azureresourcegraph/tsconfig.json
+++ b/package/microsoft/azure/azureresourcegraph/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noImplicitAny": false,
+    "target": "ES2022",
+    "strict": true,
+    "sourceMap": true,
+    "declaration": true,
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "useUnknownInCatchVariables": false
+  },
+  "include": ["src/**/*", "test/**/*", "generated/**/*"],
+  "exclude": ["dist", "node_modules", "hub-sdk"]
+}


### PR DESCRIPTION
## What this is

`@zerobias-org/module-microsoft-azure-azureresourcegraph` 1.0.0 — an Azure Resource Graph connector at `package/microsoft/azure/azureresourcegraph`, step 3 of the Azure asset-collection sequence (schema → products → module). One module serves **two products** per the msgraph many-products precedent: `microsoft.azure.azureresourcegraph` and `microsoft.azure.subscription` (both listed in `x-product-infos` and depended on at `^2.0.2`, already published).

## Operations (2 of 3 planned — listSubscriptions deliberately deferred)

Both hit `POST https://management.azure.com/providers/Microsoft.ResourceGraph/resources?api-version=2024-04-01`:

1. **`listResources`** — body query `Resources`, optional `subscriptions[]` scoping (tenant scope when omitted — supported on 2024-04-01). Paging contract: `options.$top` max 1000, `options.$skip` first page only, response `$skipToken`/`count`/`totalRecords`/`resultTruncated`; `$skipToken` is passed back on subsequent calls (it overrides `$skip`/`$top`) and paging stops when absent. `options.resultFormat: objectArray`.
2. **`listResourceContainers`** — same endpoint, query `ResourceContainers` (returns `microsoft.resources/subscriptions`, `microsoft.resources/subscriptions/resourcegroups`, `microsoft.management/managementgroups`).

The `$skipToken` is carried in `PagedResults.pageToken`; `totalRecords` populates `PagedResults.count`.

## Security access required

Azure AD client credentials (`directoryId` + `clientId`/`clientSecret`, same connectionProfile shape as msgraph: `oauthTokenProfile` + `oauthTokenState` + `x-oauth-providers: microsoft.oauth`) with the **ARM token audience** (`https://management.azure.com/.default`). The service principal needs **Azure RBAC Reader** at subscription or management-group scope. ARG returns no rows for unreadable objects and 403 only when nothing is readable. Throttling headers `x-ms-user-quota-remaining` / `x-ms-user-quota-resets-after` are documented in the securityScheme and mapped to `RateLimitExceededError` on 429.

## Dependencies / ordering

- Schema PRs **zerobias-org/schema#68** (Azure suite schema) and **zerobias-org/schema#69** (`schema-microsoft-azure-azureresourcegraph`) must land first — the api.yml `Resource` schema maps toward `AzureResourceGraphResource` (extends `AzureInventoryItem`), containers toward `AzureSubscription`/`AzureResourceGroup` semantics.
- Product packages `@zerobias-org/product-microsoft-azure-azureresourcegraph` and `@zerobias-org/product-microsoft-azure-subscription` are already published at 2.0.2 on pkg.zerobias.org (catalogs verified).

## Template fidelity notes (honest gaps)

- **Modeled on**: `amazon/aws/rexplorer` (file inventory, api.yml operation style: `x-impl-name`, `x-method-name`, pageSize/pageToken params from types-core, pagedLinkHeader), `microsoft/azure/msgraph` (connectionProfile + Azure AD client-credentials token flow), and in-repo `avigilon`/`readyplayerme` for zerobias-org conventions (package.json shape, `zb.typescript-connector` gradle plugin, lazy producer getters, `metadata()`→Down / `isSupported()`→Maybe platform stubs, `connect()` returning `ConnectionState`).
- **Generated code**: `src/` imports `../generated/api` and `../generated/model` (e.g. `AzureResourceGraphConnector`, `wrapResourceProducer`, `ConnectionProfile`) exactly as every template does; `generated/` is gitignored and produced by the hub-generator pipeline from api.yml. Not compiled locally — no `npm install`/codegen was run in this source-only PR, so exact generated symbol names (`wrapResourceContainerProducer`, `ResourceContainerApi`) follow the generator's tag-based naming convention and should be verified by CI's build.
- **Omitted intentionally**: `gate-stamp.json` and lockfiles (`package-lock.json`/`npm-shrinkwrap.json`) — CI regenerates. `.eslintrc`/`.nvmrc`/`.redocly.yaml` omitted because the two in-repo zerobias-org packages don't carry them uniformly.
- **`moduleId`**: freshly generated UUID (`6dc35a05-f3ba-4dfb-9aa5-2c6a9a1f63b5`) — replace if module IDs are assigned centrally.
- **Product catalog x-product-operations**: not used (rexplorer, the primary template, doesn't use them); the published azureresourcegraph catalog also predates api-version 2024-04-01 (lists 2019-04-01 operations only).
- **"packageNames" field**: no template carries a `packageNames` key; the two-product serving is expressed the way msgraph actually does it — multiple product dependencies + `x-product-infos` entries.
- **E2E test**: follows the `describeModule` pattern from readyplayerme; skips without `AZURE_DIRECTORY_ID`/`AZURE_CLIENT_ID`/`AZURE_CLIENT_SECRET`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)