### PR TITLE
chore(ci): PR guardrails — CODEOWNERS, template process checks, meta-repo stop-block

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# Code review for catalog content.
+#
+# Listing users here auto-requests their review on every PR.
+#
+# WARNING: GitHub silently IGNORES an unknown or non-member username — no error,
+# no requested review. Verify every handle before editing this file.
+# (e.g. "Stumpass" does not exist; the correct handle is "Stumpas".)
+#
+# Consider replacing these with a team (@zerobias-org/catalog-reviewers) so the
+# reviewer set is maintained in one place rather than once per repo.
+
+*   @catalin-t @Stumpas @kevinmccarthy

--- a/.github/pr-guard.yml.proposed
+++ b/.github/pr-guard.yml.proposed
@@ -1,0 +1,156 @@
+# ============================================================================
+# PROPOSED — not active yet.
+#
+# On merge this file moves to:   .github/workflows/pr-guard.yml
+#
+# It is parked here only because pushing a file under .github/workflows/
+# requires a GitHub token with the `workflow` scope, which the authoring
+# token does not have. Content is final and YAML-validated; the move is a
+# `git mv` with no edits.
+#
+# See the PR discussion for what each check catches and why.
+# ============================================================================
+
+name: PR Guard
+
+# Fast, secret-free structural checks that run on EVERY pull request.
+#
+# Deliberately separate from the content test workflow, which is label-gated
+# ("approved") and therefore does not run on a freshly-opened PR. These checks
+# are meant to catch structural mistakes before a reviewer spends attention.
+#
+# No secrets are used, so this is safe on pull requests from forks — which is
+# how external contributions arrive.
+#
+# TODO: once proven here, move the body to a reusable workflow in
+# zerobias-org/devops (matching publish.yml's pattern) and call it from all six
+# content repos.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    name: PR Guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Base branch must be dev (promotions excepted)
+        env:
+          BASE: ${{ github.base_ref }}
+          HEAD: ${{ github.head_ref }}
+        run: |
+          if [ "$BASE" != "main" ]; then
+            echo "base=$BASE — ok"; exit 0
+          fi
+          for b in dev qa uat; do
+            if [ "$HEAD" = "$b" ]; then
+              echo "promotion PR $HEAD -> main — ok"; exit 0
+            fi
+          done
+          echo "::error::PR targets 'main' from '$HEAD'. Contributions target 'dev'."
+          echo "Only promotion branches (dev, qa, uat) may target main."
+          exit 1
+
+      - name: Branch must be based on the target branch
+        env:
+          BASE: ${{ github.base_ref }}
+        run: |
+          # Catches a branch cut from one branch but targeting another. If the
+          # branch was cut from 'main' and targets 'dev', then 'dev' is not an
+          # ancestor of HEAD, and the PR diff silently includes every commit
+          # 'main' has that 'dev' lacks — other people's work, dragged along.
+          #
+          # Observed for real: PR #41 arrived as 81 files / +11073 where only 32
+          # were the author's; the other 49 were exactly the main->dev delta.
+          git fetch --no-tags origin "$BASE"
+          if git merge-base --is-ancestor "origin/$BASE" HEAD; then
+            echo "branch is based on '$BASE' — ok"; exit 0
+          fi
+          AHEAD=$(git rev-list --count "HEAD..origin/$BASE" || echo '?')
+          echo "::error::Branch is not based on '$BASE'."
+          echo "  'origin/$BASE' is not an ancestor of this branch, so the diff"
+          echo "  includes commits that belong to whatever branch it was cut from."
+          echo "  origin/$BASE has $AHEAD commit(s) this branch has never seen."
+          echo ""
+          echo "  Fix by rebasing onto the target:"
+          echo "    git fetch origin $BASE"
+          echo "    git rebase --onto origin/$BASE <original-base> \$(git rev-parse --abbrev-ref HEAD)"
+          echo "    git push --force-with-lease"
+          echo ""
+          echo "  Use the --onto form: a plain 'git rebase origin/$BASE' will try to"
+          echo "  replay the foreign commits rather than drop them."
+          exit 1
+
+      - name: Collect changed package directories
+        id: pkgs
+        env:
+          BASE: ${{ github.base_ref }}
+        run: |
+          git fetch --no-tags origin "$BASE"
+          git diff --name-only "origin/$BASE"...HEAD > /tmp/changed.txt || true
+          grep '^package/' /tmp/changed.txt \
+            | awk -F/ 'NF>2 {d=""; for (i=1; i<NF; i++) d = d $i "/"; print d}' \
+            | sed 's:/$::' | sort -u > /tmp/pkgdirs.txt || true
+          COUNT=$(grep -c . /tmp/pkgdirs.txt || true)
+          echo "count=${COUNT:-0}" >> "$GITHUB_OUTPUT"
+          echo "changed package dirs (${COUNT:-0}):"; cat /tmp/pkgdirs.txt || true
+
+      - name: gate-stamp.json must accompany package changes
+        if: steps.pkgs.outputs.count != '0'
+        run: |
+          FAIL=0
+          while read -r d; do
+            [ -z "$d" ] && continue
+            [ -f "$d/package.json" ] || continue
+            if ! grep -qx "$d/gate-stamp.json" /tmp/changed.txt; then
+              echo "::error file=$d/package.json::$d changed but $d/gate-stamp.json was not committed."
+              echo "  Run 'zbb gate' locally and commit the stamp — CI validates it, it does not regenerate it."
+              FAIL=1
+            fi
+          done < /tmp/pkgdirs.txt
+          exit $FAIL
+
+      - name: New packages must use the @zerobias-org scope
+        env:
+          BASE: ${{ github.base_ref }}
+        run: |
+          FAIL=0
+          ADDED=$(git diff --name-only --diff-filter=A "origin/$BASE"...HEAD \
+                  | grep -E '^package/.*/package\.json$' || true)
+          [ -z "$ADDED" ] && { echo "no new packages"; exit 0; }
+          for f in $ADDED; do
+            NAME=$(node -p "require('./$f').name || ''" 2>/dev/null || echo "")
+            case "$NAME" in
+              @zerobias-org/*) echo "$f -> $NAME — ok" ;;
+              "")  echo "::warning file=$f::could not read package name" ;;
+              *)   echo "::error file=$f::'$NAME' is outside the @zerobias-org scope"; FAIL=1 ;;
+            esac
+          done
+          exit $FAIL
+
+      - name: No package content sourced from private auditlogic repos
+        env:
+          BASE: ${{ github.base_ref }}
+        run: |
+          # Scoped to package/** on purpose: documentation legitimately refers to
+          # auditlogic, and should not trip this check.
+          ADDED=$(git diff --name-only --diff-filter=A "origin/$BASE"...HEAD \
+                  | grep '^package/' || true)
+          [ -z "$ADDED" ] && { echo "no added package files"; exit 0; }
+          HITS=$(echo "$ADDED" | xargs -r grep -lE 'github\.com[:/]auditlogic/' 2>/dev/null || true)
+          if [ -n "$HITS" ]; then
+            echo "::error::Added package files reference a private auditlogic repo:"
+            echo "$HITS" | sed 's/^/  /'
+            echo "auditlogic/* repos are PRIVATE; this repo is PUBLIC."
+            echo "Depend on the published package instead of copying its contents."
+            exit 1
+          fi
+          echo "no auditlogic provenance markers — ok"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,16 @@
+# How this was built
+
+> New modules are **generated**, not hand-authored. Build via the meta-repo:
+> https://github.com/zerobias-org/zerobias -> `.claude/skills/create-connector/`
+> (`/create-product` -> `/create-module` -> `/create-collector`).
+
+- [ ] : Built via `/create-module` (meta-repo `create-connector` flow)
+- [ ] : Brief path: `.connector/<vendor>-[<suite>-]<product>.md`
+- [ ] : Base branch is `dev`
+
+<!-- If any box above is unchecked, explain here BEFORE spending more effort.
+     Hand-authored modules are very likely to be sent back. -->
+
 # Related Issue
 - Jira Ticket Link goes here
 
@@ -19,6 +32,17 @@ When doing a `premajor` on a PR, the pull_request workflow will automatically se
 Please, use `dry-run` before labelling as `premajor`, this will flush out any possiblity that other module version may be altered by the process. (i.e. as a side effect of a `master` merge)
 
 `Pre-Majored` modules, will be graduated to their major version when merged into master.
+
+# Catalog identity
+
+- [ ] : `moduleId` in `package.json` matches an existing catalog module record — **not** a newly minted UUID. Verify that `store.Module.get(<moduleId>)` resolves.
+- [ ] : Product wiring uses product dependencies + `x-product-infos`. There is no `packageNames` authoring field — that name appears in `store.Module.list` *responses* only.
+- [ ] : `api.yml` was designed by the `/create-module` pipeline, not written by hand.
+
+# Content safety
+
+- [ ] : No files copied from a private auditlogic repo into this public repo.
+- [ ] : No credentials, tokens, or customer data anywhere in the diff.
 
 # Notes:
 

--- a/.github/workflows/pr-guard.yml
+++ b/.github/workflows/pr-guard.yml
@@ -1,16 +1,3 @@
-# ============================================================================
-# PROPOSED — not active yet.
-#
-# On merge this file moves to:   .github/workflows/pr-guard.yml
-#
-# It is parked here only because pushing a file under .github/workflows/
-# requires a GitHub token with the `workflow` scope, which the authoring
-# token does not have. Content is final and YAML-validated; the move is a
-# `git mv` with no edits.
-#
-# See the PR discussion for what each check catches and why.
-# ============================================================================
-
 name: PR Guard
 
 # Fast, secret-free structural checks that run on EVERY pull request.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,33 @@
 # Claude Instructions
 
+> [!IMPORTANT]
+> **Do not hand-author modules in this repo.**
+>
+> Modules are **generated**, never written by hand. New modules for `zerobias-org` are
+> built through the meta-repo:
+>
+> **https://github.com/zerobias-org/zerobias** -> `.claude/skills/create-connector/`
+>
+> That skill orchestrates `/create-product` -> `/create-module` -> `/create-collector`.
+> Part 2 runs `/create-module` here, which invokes `yo @zerobias-org/module` and the
+> specialist-agent pipeline described below. Do **not** bypass it with a manual `yo`
+> call, and do not write `package.json` / `api.yml` by hand.
+>
+> Two things a hand-authored module always gets wrong:
+>
+> - **`moduleId`** is the id of the catalog's module record, issued by the platform.
+>   Minting a UUID produces a module that resolves to nothing.
+> - **`packageNames`** is not an authoring field. It appears in `store.Module.list`
+>   *responses* only. Multi-product wiring is product dependencies + `x-product-infos`.
+>
+> Base branch is **`dev`**, not `main`.
+>
+> **Who contributes where.** `zerobias-org` is the contribution surface for the
+> zerobias.com catalog; auditlogic is internal. Contributor location follows *who is
+> contributing*, not whether a package is new — and content never moves from a private
+> auditlogic repo into a public `zerobias-org` one.
+
+
 ## Architecture
 
 **Flat, two-level structure:** You → Specialized worker agents (no intermediate orchestration)


### PR DESCRIPTION
Guardrails so a contributor — human or agent — landing in this repo is told the required build path *before* authoring anything, and so a malformed PR is caught before a reviewer spends attention on it.

**`PR Guard` runs on this PR and passes in 5s.** That is the first automated check this repo has ever run on a pull request.

## Why

Two PRs made the case, both from the same external contributor working on the Azure Resource Graph connector.

**`zerobias-org/module#39`** was hand-authored — no generator — and had to be closed. It targeted `main`, omitted `gate-stamp.json` deliberately, and minted a `moduleId` UUID that resolves to no catalog record.

**`zerobias-org/module#41`** arrived as **81 files, +11073/-316**, of which only **32** were the author's. The other 49 were `package/hl7/v2/**`, `.claude/**` and `bundle/package.json` — other people's work. Cause: the branch was cut from `main` and targeted `dev`; `main` is 21 commits ahead of `dev`, differing in exactly those 49 files. So it proposed merging 21 unrelated commits into `dev` as a side effect of adding one module.

Nothing caught either. **This repo has one workflow, `publish.yml`, and it triggers on `push` only** — there is no `pull_request` trigger anywhere, so `gh pr checks` on #41 reported *"no checks reported"*. The 49 foreign files were found by a human reading the diff.

Two contributing gaps this PR also closes: `CLAUDE.md` here never mentioned the meta-repo, `create-connector`, or even `/create-module`, so an agent landing in this repo had no signal that a generator flow exists; and there was no `CODEOWNERS`, so no review was auto-requested from anyone.

## What is here

**`.github/workflows/pr-guard.yml`** — five checks on every PR, **all secret-free**, deliberately so it is safe on PRs from **forks**, which is how external contributions arrive.

| Step | Catches |
|---|---|
| Base branch is `dev` | PR aimed at `main` (promotion branches `dev`/`qa`/`uat` excepted) |
| Branch is **based on** the target | branch cut from a different branch — the #41 failure |
| `gate-stamp.json` accompanies package changes | stamp not committed — CI validates it, does not regenerate it |
| New packages use `@zerobias-org` | wrong scope on a new package |
| No package content from private `auditlogic` repos | private→public copy |

**`.github/CODEOWNERS`** — auto-requests review from @catalin-t, @Stumpas, @kevinmccarthy. The file documents that **GitHub silently ignores an unknown or non-member handle** — no error, no requested review. Worth knowing: the handle is `Stumpas`, one `s`; `Stumpass` does not exist and would have quietly disabled a third of the review requirement.

**`pull_request_template.md`** — adds *How this was built* (meta-repo flow, brief path, base branch), *Catalog identity* (`moduleId` must resolve via `store.Module.get`, not be minted; product wiring uses product deps + `x-product-infos` — there is no `packageNames` authoring field, that appears in `store.Module.list` **responses** only), and *Content safety*. **Every existing item is preserved verbatim** — Jira, External APIs, conventional commits, `build.gradle.kts`, `zbb gate` + `gate-stamp.json`, the whole `premajor` section, Notes.

**`CLAUDE.md`** — stop-block after the H1 naming the two things a hand-authored module always gets wrong, and the `dev` base branch. Links are absolute, because relative links are worthless in a fork.

## Against the two PRs we have actually seen

| Check | #39 | #41 (before rebase) |
|---|---|---|
| Base branch | **caught** — targeted `main` | pass — targeted `dev` correctly |
| Branch base | — | **caught** |
| `gate-stamp` | **caught** — omitted deliberately | **caught** — no stamp |
| Scope | pass | pass |
| `auditlogic` provenance | missed | n/a |

## Two things I would rather state than oversell

**The provenance check is a cheap net, not a control.** It greps added files under `package/**` for `github.com[:/]auditlogic/`. It would **not** have caught `schema#68`, which copied 12 files out of a private repo and rewrote the markers on the way. Catching that properly means packing the candidate `@auditlogic/*` package and diffing, which needs `ZB_TOKEN` and therefore cannot run on a fork PR. It is scoped to `package/**` on purpose — documentation legitimately mentions auditlogic, including files in this very PR.

**A template can be deleted by the author.** #39 replaced it wholesale, so the existing `zbb gate` and `premajor` items never appeared in it. CODEOWNERS only *requests* review. The workflow is the only piece here with teeth.

## On the branch-base check specifically

`git merge-base --is-ancestor "origin/$BASE" HEAD` is the whole test. If a branch is cut from `main` and targets `dev`, `dev` is not an ancestor of HEAD and it fails; after a correct rebase it passes.

The failure output names how many commits the target has that the branch has not seen, and prints the `--onto` form of the rebase, because the obvious command is wrong:

```
git rebase origin/dev            # replays the foreign commits
git rebase --onto origin/dev …   # drops them
```

If you would rather this warn than fail on first pass, say so and I will flip it to a warning with the same message.

## Deliberately not here

The `moduleId`-resolves check. It needs `ZB_TOKEN`, and fork PRs get no secrets under `pull_request`; using `pull_request_target` would expose the token to untrusted code. It belongs in the existing label-gated content test, which already imports `ZB_TOKEN` from Vault.

## Follow-ups for reviewers to weigh in on

- Same treatment for `schema`, `collectorbot`, `vendor`, `product`, `suite` — **none has a PR template or CODEOWNERS**.
- Prefer a team (`@zerobias-org/catalog-reviewers`) over three hardcoded handles across six repos — one membership change instead of six edits, and one less chance at the silent-typo failure above.
- Branch protection on `dev`/`main`: require code-owner review, and require `PR Guard` as a status check.
- Move the guard into `zerobias-org/devops` as a reusable, matching `publish.yml`.
